### PR TITLE
feat: add due date and duration field support

### DIFF
--- a/src/tools/add-task.ts
+++ b/src/tools/add-task.ts
@@ -30,6 +30,30 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 .string()
                 .optional()
                 .describe('2-letter code specifying language of deadline.'),
+            dueString: z
+                .string()
+                .optional()
+                .describe('Natural language description of due date like "tomorrow at 3pm"'),
+            dueDate: z
+                .string()
+                .optional()
+                .describe('Specific date in YYYY-MM-DD format relative to user's timezone'),
+            dueDatetime: z
+                .string()
+                .optional()
+                .describe('Full ISO datetime format like "2023-12-31T15:00:00Z"'),
+            dueLang: z
+                .string()
+                .optional()
+                .describe('2-letter code specifying language of due date'),
+            duration: z
+                .number()
+                .optional()
+                .describe('Duration of the task'),
+            durationUnit: z
+                .string()
+                .optional()
+                .describe('Unit for task duration (e.g., "minute", "hour", "day")'),
         },
         async ({
             content,
@@ -40,6 +64,12 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
             labels,
             deadlineDate,
             deadlineLang,
+            dueString,
+            dueDate,
+            dueDatetime,
+            dueLang,
+            duration,
+            durationUnit,
         }) => {
             const task = await api.addTask({
                 content,
@@ -50,6 +80,12 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 labels,
                 deadlineDate,
                 deadlineLang,
+                dueString,
+                dueDate,
+                dueDatetime,
+                dueLang,
+                duration,
+                durationUnit,
             })
             return {
                 content: [

--- a/src/tools/add-task.ts
+++ b/src/tools/add-task.ts
@@ -22,71 +22,100 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 .describe('Task priority from 1 (normal) to 4 (urgent)'),
             labels: z.array(z.string()).optional(),
             parentId: z.string().optional().describe('The ID of a parent task'),
-            deadlineDate: z
-                .string()
-                .optional()
-                .describe('Specific date in YYYY-MM-DD format relative to user’s timezone.'),
-            deadlineLang: z
-                .string()
-                .optional()
-                .describe('2-letter code specifying language of deadline.'),
             dueString: z
                 .string()
                 .optional()
                 .describe('Natural language description of due date like "tomorrow at 3pm"'),
-            dueDate: z
-                .string()
-                .optional()
-                .describe('Specific date in YYYY-MM-DD format relative to user's timezone'),
-            dueDatetime: z
-                .string()
-                .optional()
-                .describe('Full ISO datetime format like "2023-12-31T15:00:00Z"'),
             dueLang: z
                 .string()
                 .optional()
                 .describe('2-letter code specifying language of due date'),
+            dueDate: z
+                .string()
+                .optional()
+                .describe('Specific date in YYYY-MM-DD format (cannot be used with dueDatetime)'),
+            dueDatetime: z
+                .string()
+                .optional()
+                .describe(
+                    'Full ISO datetime format like "2023-12-31T15:00:00Z" (cannot be used with dueDate)',
+                ),
+            deadlineDate: z
+                .string()
+                .optional()
+                .describe('Specific date in YYYY-MM-DD format for the deadline'),
+            deadlineLang: z
+                .string()
+                .optional()
+                .describe('2-letter code specifying language of deadline'),
             duration: z
                 .number()
                 .optional()
-                .describe('Duration of the task'),
+                .describe('Duration of the task (must be provided with durationUnit)'),
             durationUnit: z
-                .string()
+                .enum(['minute', 'day'])
                 .optional()
-                .describe('Unit for task duration (e.g., "minute", "hour", "day")'),
+                .describe('Unit for task duration (must be provided with duration)'),
         },
         async ({
             content,
+            description,
             projectId,
             parentId,
             assigneeId,
             priority,
             labels,
-            deadlineDate,
-            deadlineLang,
             dueString,
+            dueLang,
             dueDate,
             dueDatetime,
-            dueLang,
+            deadlineDate,
+            deadlineLang,
             duration,
             durationUnit,
         }) => {
-            const task = await api.addTask({
+            // Validate that dueDate and dueDatetime are not both provided
+            if (dueDate && dueDatetime) {
+                throw new Error('Cannot provide both dueDate and dueDatetime')
+            }
+
+            // Validate that if duration or durationUnit is provided, both must be provided
+            if ((duration && !durationUnit) || (!duration && durationUnit)) {
+                throw new Error('Must provide both duration and durationUnit, or neither')
+            }
+
+            // Create base task args
+            const baseArgs = {
                 content,
+                description,
                 projectId,
                 parentId,
                 assigneeId,
                 priority,
                 labels,
+                dueString,
+                dueLang,
                 deadlineDate,
                 deadlineLang,
-                dueString,
-                dueDate,
-                dueDatetime,
-                dueLang,
-                duration,
-                durationUnit,
-            })
+            }
+
+            // Handle due date (can only have one of dueDate or dueDatetime)
+            let taskArgs: Record<string, unknown> = {}
+            if (dueDate) {
+                taskArgs = { ...baseArgs, dueDate }
+            } else if (dueDatetime) {
+                taskArgs = { ...baseArgs, dueDatetime }
+            } else {
+                taskArgs = baseArgs
+            }
+
+            // Handle duration (must have both or neither)
+            if (duration !== undefined && durationUnit !== undefined) {
+                taskArgs = { ...taskArgs, duration, durationUnit }
+            }
+
+            const task = await api.addTask(taskArgs)
+
             return {
                 content: [
                     {

--- a/src/tools/add-task.ts
+++ b/src/tools/add-task.ts
@@ -33,21 +33,19 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
             dueDate: z
                 .string()
                 .optional()
-                .describe('Specific date in YYYY-MM-DD format (cannot be used with dueDatetime)'),
+                .describe("Specific date in YYYY-MM-DD format relative to user's timezone"),
             dueDatetime: z
                 .string()
                 .optional()
-                .describe(
-                    'Full ISO datetime format like "2023-12-31T15:00:00Z" (cannot be used with dueDate)',
-                ),
+                .describe('Full ISO datetime format like "2023-12-31T15:00:00Z"'),
             deadlineDate: z
                 .string()
                 .optional()
-                .describe('Specific date in YYYY-MM-DD format for the deadline'),
+                .describe("Specific date in YYYY-MM-DD format relative to user's timezone."),
             deadlineLang: z
                 .string()
                 .optional()
-                .describe('2-letter code specifying language of deadline'),
+                .describe('2-letter code specifying language of deadline.'),
             duration: z
                 .number()
                 .optional()

--- a/src/tools/add-task.ts
+++ b/src/tools/add-task.ts
@@ -1,4 +1,4 @@
-import type { TodoistApi } from '@doist/todoist-api-typescript'
+import type { AddTaskArgs, TodoistApi } from '@doist/todoist-api-typescript'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
@@ -100,7 +100,7 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
             }
 
             // Handle due date (can only have one of dueDate or dueDatetime)
-            let taskArgs: Record<string, unknown> = {}
+            let taskArgs: Partial<AddTaskArgs> = {}
             if (dueDate) {
                 taskArgs = { ...baseArgs, dueDate }
             } else if (dueDatetime) {
@@ -114,7 +114,7 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 taskArgs = { ...taskArgs, duration, durationUnit }
             }
 
-            const task = await api.addTask(taskArgs)
+            const task = await api.addTask(taskArgs as AddTaskArgs)
 
             return {
                 content: [

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -1,4 +1,4 @@
-import type { TodoistApi } from '@doist/todoist-api-typescript'
+import type { TodoistApi, UpdateTaskArgs } from '@doist/todoist-api-typescript'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 
@@ -96,7 +96,7 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
             }
 
             // Handle due date (can only have one of dueDate or dueDatetime)
-            let updateArgs: Record<string, unknown> = {}
+            let updateArgs: Partial<UpdateTaskArgs> = {}
             if (dueDate) {
                 updateArgs = { ...baseArgs, dueDate }
             } else if (dueDatetime) {
@@ -110,7 +110,7 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 updateArgs = { ...updateArgs, duration, durationUnit }
             }
 
-            const task = await api.updateTask(taskId, updateArgs)
+            const task = await api.updateTask(taskId, updateArgs as UpdateTaskArgs)
 
             return {
                 content: [{ type: 'text', text: JSON.stringify(task, null, 2) }],

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -29,6 +29,30 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 .string()
                 .optional()
                 .describe('2-letter code specifying language of deadline.'),
+            dueString: z
+                .string()
+                .optional()
+                .describe('Natural language description of due date like "tomorrow at 3pm"'),
+            dueDate: z
+                .string()
+                .optional()
+                .describe('Specific date in YYYY-MM-DD format relative to user's timezone'),
+            dueDatetime: z
+                .string()
+                .optional()
+                .describe('Full ISO datetime format like "2023-12-31T15:00:00Z"'),
+            dueLang: z
+                .string()
+                .optional()
+                .describe('2-letter code specifying language of due date'),
+            duration: z
+                .number()
+                .optional()
+                .describe('Duration of the task'),
+            durationUnit: z
+                .string()
+                .optional()
+                .describe('Unit for task duration (e.g., "minute", "hour", "day")'),
         },
         async ({
             taskId,
@@ -39,6 +63,12 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
             labels,
             deadlineDate,
             deadlineLang,
+            dueString,
+            dueDate,
+            dueDatetime,
+            dueLang,
+            duration,
+            durationUnit,
         }) => {
             const task = await api.updateTask(taskId, {
                 content,
@@ -48,6 +78,12 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 labels,
                 deadlineDate,
                 deadlineLang,
+                dueString,
+                dueDate,
+                dueDatetime,
+                dueLang,
+                duration,
+                durationUnit,
             })
             return {
                 content: [{ type: 'text', text: JSON.stringify(task, null, 2) }],

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -21,38 +21,40 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 .optional()
                 .describe('Task priority from 1 (normal) to 4 (urgent)'),
             labels: z.array(z.string()).optional(),
-            deadlineDate: z
-                .string()
-                .optional()
-                .describe('Specific date in YYYY-MM-DD format relative to user’s timezone.'),
-            deadlineLang: z
-                .string()
-                .optional()
-                .describe('2-letter code specifying language of deadline.'),
             dueString: z
                 .string()
                 .optional()
                 .describe('Natural language description of due date like "tomorrow at 3pm"'),
-            dueDate: z
-                .string()
-                .optional()
-                .describe('Specific date in YYYY-MM-DD format relative to user's timezone'),
-            dueDatetime: z
-                .string()
-                .optional()
-                .describe('Full ISO datetime format like "2023-12-31T15:00:00Z"'),
             dueLang: z
                 .string()
                 .optional()
                 .describe('2-letter code specifying language of due date'),
+            dueDate: z
+                .string()
+                .optional()
+                .describe('Specific date in YYYY-MM-DD format (cannot be used with dueDatetime)'),
+            dueDatetime: z
+                .string()
+                .optional()
+                .describe(
+                    'Full ISO datetime format like "2023-12-31T15:00:00Z" (cannot be used with dueDate)',
+                ),
+            deadlineDate: z
+                .string()
+                .optional()
+                .describe('Specific date in YYYY-MM-DD format for the deadline'),
+            deadlineLang: z
+                .string()
+                .optional()
+                .describe('2-letter code specifying language of deadline'),
             duration: z
                 .number()
                 .optional()
-                .describe('Duration of the task'),
+                .describe('Duration of the task (must be provided with durationUnit)'),
             durationUnit: z
-                .string()
+                .enum(['minute', 'day'])
                 .optional()
-                .describe('Unit for task duration (e.g., "minute", "hour", "day")'),
+                .describe('Unit for task duration (must be provided with duration)'),
         },
         async ({
             taskId,
@@ -61,30 +63,55 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
             assigneeId,
             priority,
             labels,
-            deadlineDate,
-            deadlineLang,
             dueString,
+            dueLang,
             dueDate,
             dueDatetime,
-            dueLang,
+            deadlineDate,
+            deadlineLang,
             duration,
             durationUnit,
         }) => {
-            const task = await api.updateTask(taskId, {
+            // Validate that dueDate and dueDatetime are not both provided
+            if (dueDate && dueDatetime) {
+                throw new Error('Cannot provide both dueDate and dueDatetime')
+            }
+
+            // Validate that if duration or durationUnit is provided, both must be provided
+            if ((duration && !durationUnit) || (!duration && durationUnit)) {
+                throw new Error('Must provide both duration and durationUnit, or neither')
+            }
+
+            // Create base update args
+            const baseArgs = {
                 content,
                 description,
                 assigneeId,
                 priority,
                 labels,
+                dueString,
+                dueLang,
                 deadlineDate,
                 deadlineLang,
-                dueString,
-                dueDate,
-                dueDatetime,
-                dueLang,
-                duration,
-                durationUnit,
-            })
+            }
+
+            // Handle due date (can only have one of dueDate or dueDatetime)
+            let updateArgs: Record<string, unknown> = {}
+            if (dueDate) {
+                updateArgs = { ...baseArgs, dueDate }
+            } else if (dueDatetime) {
+                updateArgs = { ...baseArgs, dueDatetime }
+            } else {
+                updateArgs = baseArgs
+            }
+
+            // Handle duration (must have both or neither)
+            if (duration !== undefined && durationUnit !== undefined) {
+                updateArgs = { ...updateArgs, duration, durationUnit }
+            }
+
+            const task = await api.updateTask(taskId, updateArgs)
+
             return {
                 content: [{ type: 'text', text: JSON.stringify(task, null, 2) }],
             }

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -32,21 +32,19 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
             dueDate: z
                 .string()
                 .optional()
-                .describe('Specific date in YYYY-MM-DD format (cannot be used with dueDatetime)'),
+                .describe("Specific date in YYYY-MM-DD format relative to user's timezone"),
             dueDatetime: z
                 .string()
                 .optional()
-                .describe(
-                    'Full ISO datetime format like "2023-12-31T15:00:00Z" (cannot be used with dueDate)',
-                ),
+                .describe('Full ISO datetime format like "2023-12-31T15:00:00Z"'),
             deadlineDate: z
                 .string()
                 .optional()
-                .describe('Specific date in YYYY-MM-DD format for the deadline'),
+                .describe("Specific date in YYYY-MM-DD format relative to user's timezone."),
             deadlineLang: z
                 .string()
                 .optional()
-                .describe('2-letter code specifying language of deadline'),
+                .describe('2-letter code specifying language of deadline.'),
             duration: z
                 .number()
                 .optional()


### PR DESCRIPTION
**Description:**

This PR enhances task functionality by adding comprehensive support for due date and duration fields to the Todoist MCP tools. I'm referring to issue #18. I'm aware of https://github.com/Doist/todoist-mcp/pull/19, but this PR supports deadlines, due dates, and durations. In particular, the lack of due date support is really unfortunate, so I tried to address it. If something isn't exactly as you need it, please feel free to take whatever is helpful and close the PR.

**Features:**

- Added support for natural language due dates (e.g., "tomorrow at 3pm").
- Added support for specific dates in YYYY-MM-DD format.
- Added full ISO datetime format support.
- Added language specification for due dates.
- Added task duration tracking with customizable units.

**Implementation:**

- Enhanced the `add-task.ts` and `update-task.ts` tools with new optional parameters.
- Added proper validation using Zod schema.
- Maintained backward compatibility with existing implementations.

**Benefits:**

These enhancements allow for more precise task scheduling and time management capabilities within the Todoist integration.