### PR TITLE
fix: Ensure priority enum is string for Gemini compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 build/
 node_modules/
+.worktrees/  
+.worktrees/ 

--- a/src/tools/add-task.ts
+++ b/src/tools/add-task.ts
@@ -15,9 +15,8 @@ export function registerAddTask(server: McpServer, api: TodoistApi) {
                 .optional()
                 .describe('The ID of a project collaborator to assign the task to'),
             priority: z
-                .number()
-                .min(1)
-                .max(4)
+                .enum(['1', '2', '3', '4'])
+                .transform(Number)
                 .optional()
                 .describe('Task priority from 1 (normal) to 4 (urgent)'),
             labels: z.array(z.string()).optional(),

--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -15,9 +15,8 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
                 .optional()
                 .describe('The ID of a project collaborator to assign the task to'),
             priority: z
-                .number()
-                .min(1)
-                .max(4)
+                .enum(['1', '2', '3', '4'])
+                .transform(Number)
                 .optional()
                 .describe('Task priority from 1 (normal) to 4 (urgent)'),
             labels: z.array(z.string()).optional(),


### PR DESCRIPTION
This PR addresses an issue where the `priority` field in `add-task` and `update-task` tools caused errors when used with Gemini's Function Calling.

**Problem:**
The `priority` field was defined as a number type (`z.number().min(1).max(4)`). However, Gemini's Function Calling expects enum values to be passed as strings. This mismatch resulted in a `TYPE_STRING expected, got number` error when the `priority` value was passed to Gemini.

**Solution:**
The `priority` field has been updated to use `z.enum(['1', '2', '3', '4']).transform(Number)`. This ensures that:
1. The external representation of the `priority` enum is a string (e.g., '1', '2', '3', '4'), satisfying Gemini's requirement.
2. Internally, the value is transformed back to a number (1, 2, 3, 4) for compatibility with the Todoist API.

This change resolves the type mismatch and allows the `todoist-mcp` repository to function correctly when integrated with Gemini CLI.