### PR TITLE
fixes #78: clarify dueString parameter usage for removing task due dates

### DIFF
--- a/src/tools/update-task.ts
+++ b/src/tools/update-task.ts
@@ -24,7 +24,9 @@ export function registerUpdateTask(server: McpServer, api: TodoistApi) {
             dueString: z
                 .string()
                 .optional()
-                .describe('Natural language description of due date like "tomorrow at 3pm"'),
+                .describe(
+                    'Natural language description of due date like "tomorrow at 3pm". Use "no date" or "no due date" to remove an existing due date.',
+                ),
             dueLang: z
                 .string()
                 .optional()


### PR DESCRIPTION
## Description

This PR improves the documentation for the `dueString` parameter in the `update-task` tool to clarify how to remove existing due dates from tasks.

## Problem

The current parameter description only mentions setting due dates but doesn't explain how to remove them. This has led to confusion where AI agents and developers attempt to use `null` or empty strings to remove due dates, which doesn't work with the Todoist API.

## Solution

Updated the `dueString` parameter description to explicitly mention that `"no date"` or `"no due date"` should be used to remove existing due dates.

### Changes Made

- **File**: `src/tools/update-task.ts`
- **Change**: Updated the `describe()` method for the `dueString` parameter

## Testing

✅ Verified that `dueString: "no date"` successfully removes due dates  
✅ Verified that `dueString: "no due date"` successfully removes due dates  
✅ Confirmed that empty strings and null values do not remove due dates (as expected)  
✅ Existing functionality for setting due dates remains unchanged  

## Related

- Aligns with [Todoist REST API documentation](https://developer.todoist.com/rest/v2/#update-a-task)
- Improves developer experience and AI agent compatibility
- No breaking changes to existing functionality
