### PR TITLE
fix: cap pagination to 3 pages

### DIFF
--- a/src/tools/get-labels.ts
+++ b/src/tools/get-labels.ts
@@ -1,14 +1,10 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { getMaxPaginatedResults } from '../utils/get-max-paginated-results.js'
 
 export function registerGetLabels(server: McpServer, api: TodoistApi) {
     server.tool('get-labels', 'Get all labels in Todoist', {}, async () => {
-        let response = await api.getLabels()
-        const labels = response.results
-        while (response.nextCursor) {
-            response = await api.getLabels({ cursor: response.nextCursor })
-            labels.push(...response.results)
-        }
+        const labels = await getMaxPaginatedResults((params) => api.getLabels(params))
         return {
             content: labels.map((label) => ({
                 type: 'text',

--- a/src/tools/get-projects.ts
+++ b/src/tools/get-projects.ts
@@ -1,14 +1,10 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { getMaxPaginatedResults } from '../utils/get-max-paginated-results.js'
 
 export function registerGetProjects(server: McpServer, api: TodoistApi) {
     server.tool('get-projects', 'Get all projects from Todoist', {}, async () => {
-        let response = await api.getProjects()
-        const projects = response.results
-        while (response.nextCursor) {
-            response = await api.getProjects({ cursor: response.nextCursor })
-            projects.push(...response.results)
-        }
+        const projects = await getMaxPaginatedResults((params) => api.getProjects(params))
         return {
             content: projects.map((project) => ({
                 type: 'text',

--- a/src/tools/get-shared-labels.ts
+++ b/src/tools/get-shared-labels.ts
@@ -1,6 +1,7 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
+import { getMaxPaginatedResults } from '../utils/get-max-paginated-results.js'
 
 export function registerGetSharedLabels(server: McpServer, api: TodoistApi) {
     server.tool(
@@ -10,12 +11,9 @@ export function registerGetSharedLabels(server: McpServer, api: TodoistApi) {
             omitPersonal: z.boolean().optional(),
         },
         async ({ omitPersonal }) => {
-            let response = await api.getSharedLabels({ omitPersonal })
-            const labels = response.results
-            while (response.nextCursor) {
-                response = await api.getSharedLabels({ omitPersonal, cursor: response.nextCursor })
-                labels.push(...response.results)
-            }
+            const labels = await getMaxPaginatedResults((params) =>
+                api.getSharedLabels({ omitPersonal, ...params }),
+            )
             return {
                 content: labels.map((label) => ({
                     type: 'text',

--- a/src/tools/get-task-comments.ts
+++ b/src/tools/get-task-comments.ts
@@ -1,6 +1,7 @@
 import type { TodoistApi } from '@doist/todoist-api-typescript'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
+import { getMaxPaginatedResults } from '../utils/get-max-paginated-results.js'
 
 export function registerGetTaskComments(server: McpServer, api: TodoistApi) {
     server.tool(
@@ -8,12 +9,9 @@ export function registerGetTaskComments(server: McpServer, api: TodoistApi) {
         'Get comments from a task in Todoist',
         { taskId: z.string() },
         async ({ taskId }) => {
-            let response = await api.getComments({ taskId })
-            const comments = response.results
-            while (response.nextCursor) {
-                response = await api.getComments({ taskId, cursor: response.nextCursor })
-                comments.push(...response.results)
-            }
+            const comments = await getMaxPaginatedResults((params) =>
+                api.getComments({ taskId, ...params }),
+            )
             return {
                 content: comments.map((comment) => ({
                     type: 'text',

--- a/src/utils/get-max-paginated-results.ts
+++ b/src/utils/get-max-paginated-results.ts
@@ -1,0 +1,33 @@
+/**
+ * Generic function to cap paginated results from a Todoist API function
+ * @param apiFunction - The Todoist API function that accepts cursor parameter
+ * @param params - Initial parameters to pass to the API function
+ * @param maxPages - Maximum number of pages to fetch (default: 3)
+ * @returns Promise with all results from paginated API calls
+ */
+export async function getMaxPaginatedResults<
+    T extends { cursor: string | null },
+    R extends { results: unknown[]; nextCursor: string | null },
+>(
+    apiFunction: (params: T) => Promise<R>,
+    params: T = {} as T,
+    maxPages: number = 3,
+): Promise<unknown[]> {
+    const results: unknown[] = []
+    let currentParams = { ...params }
+    let pagesFetched = 0
+
+    while (pagesFetched < maxPages) {
+        const response = await apiFunction(currentParams)
+        results.push(...response.results)
+
+        if (!response.nextCursor) {
+            break
+        }
+
+        currentParams = { ...currentParams, cursor: response.nextCursor }
+        pagesFetched++
+    }
+
+    return results
+}


### PR DESCRIPTION
Returning all projects, labels, and sections is problematic as we reach the LLM max token quite quickly.

Instead, cap the number of pages to 3 so there is not too many results.

Fix https://github.com/Doist/todoist-mcp/issues/85.
Fix https://github.com/Doist/todoist-mcp/issues/49.
