### PR TITLE
#91 - fix TODOIST_API_TOKEN to be TODOIST_API_KEY in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then, in your `claude_desktop_config.json`, add a new MCP server:
             "command": "node",
             "args": ["/path/to/repo/build/index.js"],
             "env": {
-                "TODOIST_API_TOKEN": "your_todoist_api_key"
+                "TODOIST_API_KEY": "your_todoist_api_key"
             }
         }
     }


### PR DESCRIPTION
# PURPOSE

Resolves #91.

The server expects the environment variable `TODOIST_API_KEY`:

<img width="1580" height="672" alt="CleanShot 2025-07-19 at 19 48 14@2x" src="https://github.com/user-attachments/assets/0971fbe0-fc5e-4ac6-bb72-1aaab8e41c49" />

... but the `README.md` currently instructs users to use `TODOIST_API_TOKEN`.

People following the current `README.md` will fail to start the MCP server.

# METHOD

Simple README change to fix the environment variable name in the example.

# TEST

Smoke-tested manually.

# OTHER

Unsure how this relates to #84, since it seems like someone intentionally made this change away from the working env var to a non-working one. 🤔

Cursor + o3 convo suggests that `TODOIST_API_TOKEN` was never correct, and a manual grep of the codebase suggests it never existed in this codebase:

<details>
<summary>Click to toggle Cursor convo open/closed</summary>

```md
# Confusion over API key and token
_Exported on 7/19/2025 at 19:40:00 PDT from Cursor (1.2.4)_

---

**User**

In this repo, there was a PR that requested to change the README from `TODOIST_API_KEY` to `TODOIST_API_TOKEN` a few days ago. The developer had said that using `TODOIST_API_KEY` was breaking his Claude integration. However, today, someone filed a PR saying that the latest branch isn't working with `TODOIST_API_TOKEN`, and instead it needs to be `TODOIST_API_KEY`.

Any idea what's going on here? Which one should it be? Why does the confusion exist?

---

**Cursor**

Short version  
1. The code that actually runs (`src/index.ts`) looks for an environment variable called `TODOIST_API_KEY`.  
2. Nowhere in the codebase is `TODOIST_API_TOKEN` referenced.  
3. The confusion comes from a README edit – the sample Claude-desktop config was changed from `TODOIST_API_KEY` ➜ `TODOIST_API_TOKEN`, but the code wasn’t updated to match.  
4. Until someone changes the code, the server will only work when you export `TODOIST_API_KEY=<your-token>`.

Why it happened  
• Todoist itself calls the secret an “API token”, while a lot of older sample code (including the TypeScript SDK README) uses the word “key”.  
• A contributor wanted the wording in the README to line up with Todoist’s UI and changed the env-var name there, assuming the code also used TOKEN (or planning to rename it but never did).  
• That change broke anyone who copied the new README, because the executable code still throws if `process.env.TODOIST_API_KEY` is undefined.

Which one “should” it be?  
Either name works technically—the value is just passed straight to `new TodoistApi(...)`.  What matters is consistency:

• Easiest immediate fix for users: keep the code as-is and revert the README to say `TODOIST_API_KEY`.  
• Alternatively, rename the check in `src/index.ts` to `TODOIST_API_TOKEN` (and maybe accept both for backwards compatibility).

Until a change is merged, tell everyone to use `TODOIST_API_KEY` (or set both names to the same value).

---

**User**

Does a prior commit maybe reference `TODOIST_API_TOKEN`?

---

**Cursor**

I checked the entire Git history:

• Only one commit ever contained the literal string `TODOIST_API_TOKEN`:  
  41b87cc  “fix: update environment variable name from TODOIST_API_KEY to TODOIST_API_TOKEN in README (#84)”

That commit touches just one line in `README.md`; no source files were changed.  
All other commits (and the current code) consistently use `TODOIST_API_KEY`.

So the only historical reference to `TODOIST_API_TOKEN` is that README edit—no earlier version of the codebase has ever expected that variable.
```

</details>

Maybe @maxmelnick got this repo mixed up with [a different Todoist MCP server](https://github.com/abhiz123/todoist-mcp-server)? 🤔  That _other_ repo [**DOES** use `TODOIST_API_TOKEN`](https://github.com/abhiz123/todoist-mcp-server/blob/70802047442604b197c59e3ea0706f173f4e6e48/src/index.ts#L145).