### PR TITLE
perf: trim redundant output schema descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,20 @@ When you need to support clearing an optional field:
 - Maintains backward compatibility through dual handling
 - Creates self-documenting APIs with explicit action strings
 
+### Describing output schema fields
+
+Every tool's `outputSchema` is sent to clients on every `tools/list`, and the shared schemas in `src/utils/output-schemas.ts` are inlined once per tool that uses them — so a description on `TaskSchema.id` is paid eight times over.
+
+Describe an output field only where the schema cannot express the thing itself:
+
+- units or formats — `'ISO 8601.'`, `'Bytes.'`, `'e.g. "2h30m".'`
+- conventions that are not derivable — `priority: 'p1 is highest, p4 lowest.'`
+- unions — `recurring: 'False when not recurring, otherwise the recurrence string.'`
+- conditional presence — `workspaceId: 'Undefined for personal projects.'`
+- non-obvious meaning — `isUncompletable: 'An organizational header, not a real task.'`
+
+Leave it off when the description would restate the field name (`id`, `projectId`, `name`), or list values an `enum` already carries. Note this is the _output_ side only: input field descriptions are how a model learns to call the tool correctly and should stay as full as they need to be.
+
 ## Adding a New Tool
 
 `src/tool-registry.ts` is the single source of truth for the tool surface. `src/mcp-server.ts`, the `tools` export in `src/index.ts`, `scripts/run-tool.ts`, `scripts/validate-schemas.ts` and `src/token-footprint.test.ts` all derive from it, so adding a tool there wires it up everywhere.

--- a/src/token-footprint.test.ts
+++ b/src/token-footprint.test.ts
@@ -92,9 +92,10 @@ function measure(): Row[] {
 }
 
 // Budget for the combined fixed token cost (tools/list payload + instructions).
-// Bump deliberately when adding tools or expanding descriptions. Override at
-// runtime with MCP_TOKEN_BUDGET=NNNN to experiment without editing the source.
-const DEFAULT_TOKEN_BUDGET = 41_000
+// Treat it as a ratchet rather than headroom: it should move down over time, and
+// a rise needs justifying in the PR that causes it. Override at runtime with
+// MCP_TOKEN_BUDGET=NNNN to experiment without editing the source.
+const DEFAULT_TOKEN_BUDGET = 37_000
 const TOKEN_BUDGET = Number(process.env.MCP_TOKEN_BUDGET ?? DEFAULT_TOKEN_BUDGET)
 
 describe('token footprint baseline', () => {

--- a/src/tools/find-activity.ts
+++ b/src/tools/find-activity.ts
@@ -69,12 +69,10 @@ const ArgsSchema = {
 
 const OutputSchema = {
     events: z.array(ActivityEventSchema).describe('The activity events.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of events in this page.'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    hasMore: z.boolean(),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findActivity = {

--- a/src/tools/find-comments.ts
+++ b/src/tools/find-comments.ts
@@ -34,8 +34,8 @@ const OutputSchema = {
             'The type of search performed: "single" (comment ID), "task" (task ID), or "project" (project ID).',
         ),
     searchId: z.string().describe('The ID that was searched for (comment, task, or project ID).'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    hasMore: z.boolean(),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of comments in this page.'),
 }
 

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -102,12 +102,10 @@ const ArgsSchema = {
 
 const OutputSchema = {
     tasks: z.array(TaskOutputSchema).describe('The found completed tasks.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of tasks in this page.'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    hasMore: z.boolean(),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findCompletedTasks = {

--- a/src/tools/find-labels.ts
+++ b/src/tools/find-labels.ts
@@ -31,17 +31,15 @@ const ArgsSchema = {
 
 const OutputSchema = {
     labels: z.array(LabelOutputSchema).describe('The found personal labels.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of labels in this page.'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
+    hasMore: z.boolean(),
     sharedLabels: z
         .array(z.string())
         .describe(
             'Names of all shared labels visible to you. These have no IDs or metadata — use their names directly when filtering tasks.',
         ),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findLabels = {

--- a/src/tools/find-project-collaborators.ts
+++ b/src/tools/find-project-collaborators.ts
@@ -40,9 +40,7 @@ const OutputSchema = {
         .number()
         .optional()
         .describe('The total number of available users before the search filter was applied.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findProjectCollaborators = {

--- a/src/tools/find-projects.ts
+++ b/src/tools/find-projects.ts
@@ -51,12 +51,10 @@ const ArgsSchema = {
 
 const OutputSchema = {
     projects: z.array(ProjectOutputSchema).describe('The found projects.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of projects in this page.'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    hasMore: z.boolean(),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findProjects = {

--- a/src/tools/find-sections.ts
+++ b/src/tools/find-sections.ts
@@ -31,9 +31,7 @@ type SectionSummary = {
 const OutputSchema = {
     sections: z.array(SectionOutputSchema).describe('The found sections.'),
     totalCount: z.number().describe('The total number of sections found.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findSections = {

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -72,12 +72,10 @@ export const ArgsSchema = {
 
 const OutputSchema = {
     tasks: z.array(TaskOutputSchema).describe('The found tasks.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of tasks in this page.'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    hasMore: z.boolean(),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findTasksByDate = {

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -75,12 +75,10 @@ const ArgsSchema = {
 
 const OutputSchema = {
     tasks: z.array(TaskOutputSchema).describe('The found tasks.'),
-    nextCursor: z.string().optional().describe('Cursor for the next page of results.'),
+    nextCursor: z.string().optional(),
     totalCount: z.number().describe('The total number of tasks in this page.'),
-    hasMore: z.boolean().describe('Whether there are more results available.'),
-    appliedFilters: z
-        .record(z.string(), z.unknown())
-        .describe('The filters that were applied to the search.'),
+    hasMore: z.boolean(),
+    appliedFilters: z.record(z.string(), z.unknown()),
 }
 
 const findTasks = {

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -24,7 +24,7 @@ export const ColorSchema = z
     .describe(colorDescription)
 
 // For OUTPUT: strict enum. Kept for reference — output schemas use ColorOutputSchema.
-export const ColorKeySchema = z.enum(colorKeys).describe('The color key of the entity.')
+export const ColorKeySchema = z.enum(colorKeys)
 
 // For OUTPUT (tolerant): accepts valid color keys and silently coerces unrecognised values
 // to undefined instead of raising a validation error.  Fixes both failure modes described in issue #343:
@@ -32,8 +32,4 @@ export const ColorKeySchema = z.enum(colorKeys).describe('The color key of the e
 //   2. Name search — silent empty result set due to swallowed validation error
 // This is the output-side counterpart to ColorSchema, which uses .preprocess()/.catch() for
 // input normalisation (added in PR #328).
-export const ColorOutputSchema = z
-    .enum(colorKeys)
-    .optional()
-    .catch(undefined)
-    .describe('The color key of the entity.')
+export const ColorOutputSchema = z.enum(colorKeys).optional().catch(undefined)

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -7,77 +7,55 @@ import { PrioritySchema } from './priorities.js'
  * Schema for a mapped task object returned by tools
  */
 const TaskSchema = z.object({
-    id: z.string().describe('The unique ID of the task.'),
-    content: z.string().describe('The task title/content.'),
-    description: z.string().describe('The task description.'),
-    dueDate: z.string().optional().describe('The due date of the task (ISO 8601 format).'),
+    id: z.string(),
+    content: z.string().describe('Task title.'),
+    description: z.string(),
+    dueDate: z.string().optional().describe('ISO 8601.'),
     recurring: z
         .union([z.boolean(), z.string()])
-        .describe('Whether the task is recurring, or the recurrence string.'),
-    deadlineDate: z
-        .string()
-        .optional()
-        .describe('The deadline date of the task (ISO 8601 format).'),
-    priority: PrioritySchema.describe(
-        'The priority level: p1 (highest), p2 (high), p3 (medium), p4 (lowest).',
-    ),
-    projectId: z.string().describe('The ID of the project this task belongs to.'),
-    sectionId: z.string().optional().describe('The ID of the section this task belongs to.'),
-    parentId: z.string().optional().describe('The ID of the parent task (for subtasks).'),
-    labels: z.array(z.string()).optional().describe('The labels attached to this task.'),
-    duration: z.string().optional().describe('The duration of the task (e.g., "2h30m").'),
-    responsibleUid: z
-        .string()
-        .optional()
-        .describe('The UID of the user responsible for this task.'),
-    isUncompletable: z
-        .boolean()
-        .optional()
-        .describe('Whether the task is uncompletable (organizational header).'),
-    assignedByUid: z.string().optional().describe('The UID of the user who assigned this task.'),
-    checked: z.boolean().describe('Whether the task is checked/completed.'),
-    completedAt: z.string().optional().describe('When the task was completed (ISO 8601 format).'),
-    addedAt: z.string().optional().describe('When the task was created (ISO 8601 format).'),
+        .describe('False when not recurring, otherwise the recurrence string.'),
+    deadlineDate: z.string().optional().describe('ISO 8601.'),
+    priority: PrioritySchema.describe('p1 is highest, p4 lowest.'),
+    projectId: z.string(),
+    sectionId: z.string().optional(),
+    parentId: z.string().optional(),
+    labels: z.array(z.string()).optional(),
+    duration: z.string().optional().describe('e.g. "2h30m".'),
+    responsibleUid: z.string().optional(),
+    isUncompletable: z.boolean().optional().describe('An organizational header, not a real task.'),
+    assignedByUid: z.string().optional(),
+    checked: z.boolean().describe('Whether the task is completed.'),
+    completedAt: z.string().optional().describe('ISO 8601.'),
+    addedAt: z.string().optional().describe('ISO 8601.'),
 })
 
 /**
  * Schema for a mapped project object returned by tools
  */
 const ProjectSchema = z.object({
-    id: z.string().describe('The unique ID of the project.'),
-    name: z.string().describe('The name of the project.'),
-    description: z.string().describe('The description of the project (empty string if none).'),
+    id: z.string(),
+    name: z.string(),
+    description: z.string().describe('Empty string when none.'),
     color: ColorOutputSchema,
-    isFavorite: z.boolean().describe('Whether the project is marked as favorite.'),
-    isShared: z.boolean().describe('Whether the project is shared.'),
-    parentId: z.string().optional().describe('The ID of the parent project (for sub-projects).'),
-    inboxProject: z.boolean().describe('Whether this is the inbox project.'),
-    viewStyle: z.string().describe('The view style of the project (list, board, calendar).'),
-    workspaceId: z
-        .string()
-        .optional()
-        .describe(
-            'The ID of the workspace this project belongs to (undefined for personal projects).',
-        ),
-    folderId: z
-        .string()
-        .optional()
-        .describe('The ID of the folder this project belongs to (workspace projects only).'),
-    childOrder: z.number().describe('The ordering index of the project among its siblings.'),
-    isArchived: z.boolean().describe('Whether the project is archived.'),
+    isFavorite: z.boolean(),
+    isShared: z.boolean(),
+    parentId: z.string().optional(),
+    inboxProject: z.boolean(),
+    viewStyle: z.string().describe('list, board or calendar.'),
+    workspaceId: z.string().optional().describe('Undefined for personal projects.'),
+    folderId: z.string().optional().describe('Workspace projects only.'),
+    childOrder: z.number().describe('Ordering index among siblings.'),
+    isArchived: z.boolean(),
 })
 
 /**
  * Schema for a section object returned by tools
  */
 const SectionSchema = z.object({
-    id: z.string().describe('The unique ID of the section.'),
-    name: z.string().describe('The name of the section.'),
-    sectionOrder: z.number().describe('The ordering index of the section within its project.'),
-    description: z
-        .string()
-        .optional()
-        .describe('The description of the section. Supports Markdown.'),
+    id: z.string(),
+    name: z.string(),
+    sectionOrder: z.number().describe('Ordering index within the project.'),
+    description: z.string().optional().describe('Supports Markdown.'),
 })
 
 type SectionSummary = z.infer<typeof SectionSchema>
@@ -96,122 +74,103 @@ function toSectionSummary({ id, name, sectionOrder, description }: Section): Sec
  * Schema for a file attachment in a comment
  */
 const AttachmentSchema = z.object({
-    resourceType: z.string().describe('The type of resource (file, url, image, etc).'),
-    fileName: z.string().optional().describe('The name of the file.'),
-    fileSize: z.number().optional().describe('The size of the file in bytes.'),
-    fileType: z.string().optional().describe('The MIME type of the file.'),
-    fileUrl: z.string().optional().describe('The URL to access the file.'),
-    fileDuration: z
-        .number()
-        .optional()
-        .describe('The duration in milliseconds (for audio/video files).'),
-    uploadState: z
-        .enum(['pending', 'completed'])
-        .optional()
-        .describe('The upload state of the file.'),
-    url: z.string().optional().describe('The URL for link/url resource types.'),
-    title: z.string().optional().describe('The title for link/url resource types.'),
-    image: z.string().optional().describe('The image URL for image resource types.'),
-    imageWidth: z.number().optional().describe('The width of the image in pixels.'),
-    imageHeight: z.number().optional().describe('The height of the image in pixels.'),
+    resourceType: z.string().describe('file, url, image, etc.'),
+    fileName: z.string().optional(),
+    fileSize: z.number().optional().describe('Bytes.'),
+    fileType: z.string().optional().describe('MIME type.'),
+    fileUrl: z.string().optional(),
+    fileDuration: z.number().optional().describe('Milliseconds, for audio/video.'),
+    uploadState: z.enum(['pending', 'completed']).optional(),
+    url: z.string().optional().describe('For link/url resource types.'),
+    title: z.string().optional().describe('For link/url resource types.'),
+    image: z.string().optional().describe('For image resource types.'),
+    imageWidth: z.number().optional().describe('Pixels.'),
+    imageHeight: z.number().optional().describe('Pixels.'),
 })
 
 /**
  * Schema for a comment object returned by tools
  */
 const CommentSchema = z.object({
-    id: z.string().describe('The unique ID of the comment.'),
-    taskId: z.string().optional().describe('The ID of the task this comment belongs to.'),
-    projectId: z.string().optional().describe('The ID of the project this comment belongs to.'),
-    content: z.string().describe('The content of the comment.'),
-    postedAt: z.string().describe('When the comment was posted (ISO 8601 format).'),
-    postedUid: z.string().optional().describe('The UID of the user who posted this comment.'),
-    fileAttachment: AttachmentSchema.optional().describe('File attachment information, if any.'),
+    id: z.string(),
+    taskId: z.string().optional(),
+    projectId: z.string().optional(),
+    content: z.string(),
+    postedAt: z.string().describe('ISO 8601.'),
+    postedUid: z.string().optional(),
+    fileAttachment: AttachmentSchema.optional(),
 })
 
 /**
  * Schema for an activity event object returned by tools
  */
 const ActivityEventSchema = z.object({
-    id: z.string().optional().describe('The unique ID of the activity event.'),
-    objectType: z
-        .string()
-        .describe('The type of object this event relates to (task, project, etc).'),
-    objectId: z.string().describe('The ID of the object this event relates to.'),
-    eventType: z.string().describe('The type of event (added, updated, deleted, completed, etc).'),
-    eventDate: z.string().describe('When the event occurred (ISO 8601 format).'),
-    parentProjectId: z.string().optional().describe('The ID of the parent project.'),
-    parentItemId: z.string().optional().describe('The ID of the parent item.'),
-    initiatorId: z.string().optional().describe('The ID of the user who initiated this event.'),
-    extraData: z.record(z.string(), z.unknown()).optional().describe('Additional event data.'),
+    id: z.string().optional(),
+    objectType: z.string().describe('task, project, etc.'),
+    objectId: z.string(),
+    eventType: z.string().describe('added, updated, deleted, completed, etc.'),
+    eventDate: z.string().describe('ISO 8601.'),
+    parentProjectId: z.string().optional(),
+    parentItemId: z.string().optional(),
+    initiatorId: z.string().optional().describe('User who initiated the event.'),
+    extraData: z.record(z.string(), z.unknown()).optional(),
 })
 
 /**
  * Schema for a user/collaborator object returned by tools
  */
 const CollaboratorSchema = z.object({
-    id: z.string().describe('The unique ID of the user.'),
-    name: z.string().describe('The full name of the user.'),
-    email: z.string().describe('The email address of the user.'),
+    id: z.string(),
+    name: z.string(),
+    email: z.string(),
 })
 
 /**
  * Schema for a label object returned by tools
  */
 const LabelSchema = z.object({
-    id: z.string().describe('The unique ID of the label.'),
-    name: z.string().describe('The name of the label.'),
+    id: z.string(),
+    name: z.string(),
     color: ColorOutputSchema,
-    order: z.number().optional().catch(undefined).describe('The display order of the label.'),
-    isFavorite: z.boolean().describe('Whether the label is marked as favorite.'),
+    order: z.number().optional().catch(undefined).describe('Display order.'),
+    isFavorite: z.boolean(),
 })
 
 /**
  * Schema for a reminder due date
  */
 const ReminderDueSchema = z.object({
-    isRecurring: z.boolean().describe('Whether this is a recurring reminder.'),
+    isRecurring: z.boolean(),
     string: z.string().describe('Human-readable due string.'),
-    date: z.string().describe('Due date in ISO format.'),
-    datetime: z.string().optional().describe('Due datetime in ISO format.'),
-    timezone: z.string().optional().describe('Timezone of the reminder.'),
+    date: z.string().describe('ISO 8601.'),
+    datetime: z.string().optional().describe('ISO 8601.'),
+    timezone: z.string().optional(),
 })
 
 /**
  * Schema for a mapped reminder object returned by tools
  */
 const ReminderSchema = z.object({
-    id: z.string().describe('The unique ID of the reminder.'),
-    taskId: z.string().describe('The task ID this reminder belongs to.'),
-    type: z.enum(REMINDER_TYPES).describe('The type of reminder: relative, absolute, or location.'),
-    minuteOffset: z
-        .number()
-        .optional()
-        .describe('Minutes before due time to trigger (relative reminders only).'),
-    due: ReminderDueSchema.optional().describe(
-        'Due date info (absolute and sometimes relative reminders).',
-    ),
-    name: z.string().optional().describe('Location name (location reminders only).'),
-    locLat: z.string().optional().describe('Latitude (location reminders only).'),
-    locLong: z.string().optional().describe('Longitude (location reminders only).'),
-    locTrigger: z
-        .enum(LOCATION_TRIGGERS)
-        .optional()
-        .describe('Trigger type: on_enter or on_leave (location reminders only).'),
-    radius: z.number().optional().describe('Geofence radius in meters (location reminders only).'),
-    isUrgent: z
-        .boolean()
-        .optional()
-        .describe('Whether this is an urgent reminder (relative and absolute reminders only).'),
+    id: z.string(),
+    taskId: z.string(),
+    type: z.enum(REMINDER_TYPES),
+    minuteOffset: z.number().optional().describe('Minutes before due. Relative reminders only.'),
+    due: ReminderDueSchema.optional().describe('Absolute, and sometimes relative, reminders.'),
+    name: z.string().optional().describe('Location name. Location reminders only.'),
+    locLat: z.string().optional().describe('Location reminders only.'),
+    locLong: z.string().optional().describe('Location reminders only.'),
+    locTrigger: z.enum(LOCATION_TRIGGERS).optional().describe('Location reminders only.'),
+    radius: z.number().optional().describe('Geofence radius in metres. Location reminders only.'),
+    isUrgent: z.boolean().optional().describe('Relative and absolute reminders only.'),
 })
 
 /**
  * Schema for batch operation failure
  */
 const FailureSchema = z.object({
-    item: z.string().describe('The item that failed (usually an ID or identifier).'),
-    error: z.string().describe('The error message.'),
-    code: z.string().optional().describe('The error code, if available.'),
+    item: z.string().describe('Usually the ID of the item that failed.'),
+    error: z.string(),
+    code: z.string().optional(),
 })
 
 export {


### PR DESCRIPTION
Replaces #560, which tried to stop advertising output schemas altogether. That turned out to be the wrong trade — see the closing comment there — so this takes the part of the win that carries no risk.

## What

Every tool's `outputSchema` ships on every `tools/list`, and the shared schemas in `src/utils/output-schemas.ts` are inlined once per tool that uses them. A single description on `TaskSchema.id` was therefore paid eight times over, and most of them restated the field name:

```
id           "The unique ID of the task."
projectId    "The ID of the project this task belongs to."
color        "The color key of the entity."
hasMore      "Whether there are more results available."
```

Those are gone. What stays is anything the schema cannot express on its own:

| kept | why |
|---|---|
| `dueDate: 'ISO 8601.'` | format, not derivable from `string` |
| `priority: 'p1 is highest, p4 lowest.'` | the enum does not say which end is which |
| `recurring: 'False when not recurring, otherwise the recurrence string.'` | a `boolean \| string` union |
| `workspaceId: 'Undefined for personal projects.'` | conditional presence |
| `isUncompletable: 'An organizational header, not a real task.'` | non-obvious meaning |
| `duration: 'e.g. "2h30m".'` | format |

Where a kept description was wordy it got shortened — `"The due date of the task (ISO 8601 format)"` → `"ISO 8601"`.

## Numbers

```
output-schema descriptions   7,115 → 4,074
combined fixed cost         39,478 → 35,776
```

Deliberately narrower than stripping every output description, which would have saved 9,259 rather than 3,702. The remaining 4,074 is not padding: batch-failure semantics ("A failure here does not affect the other items"), child-list truncation rules, and unions the JSON Schema type alone does not convey. Cutting those would trade real meaning for tokens.

## What is not touched

**The output side only.** Tool descriptions and input field descriptions are how a model decides whether and how to call a tool; both are untouched. `ColorSchema` is a good illustration — its *input* description still enumerates all twenty valid colours, while its *output* counterpart no longer says "The color key of the entity".

Nothing about the tool surface changes: same 47 tools, same schemas advertised, same `structuredContent`. Consumers that read output schemas — [Automations](https://github.com/Doist/automations) shows the authoring model each tool's output field names so it can reference them from follow-up steps — keep every field name, type and pagination key. That is what #560 would have taken away.

## Guardrails

`TOKEN_BUDGET` drops 41,000 → 37,000 and is now documented as a ratchet rather than headroom. `AGENTS.md` gains the rule so new tools follow it: describe an output field only where the schema cannot express the thing itself.

## Verification

`npm test` (72 files, 1133 tests), `type-check`, `format:check`, `lint:schemas` (47 tools) all clean.

## Next

The bulk of the remaining cost is input schemas (~10.6k, over half of it descriptions) and the `instructions` string (3,108). That is the follow-up work in #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
