### PR TITLE
fix: drop task recommendations from project health

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "12.5.6",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-sdk": "13.0.2",
+                "@doist/todoist-sdk": "14.0.0",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -499,9 +499,9 @@
             }
         },
         "node_modules/@doist/todoist-sdk": {
-            "version": "13.0.2",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-13.0.2.tgz",
-            "integrity": "sha512-JdyI+gbqvA4oWG/QHOAE7L0iiAK/ycrO+X8avw/9H2KWs7ApSDPZEu5KpH6YENm+knW9ezcvgLSTUdEwbmvIiw==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-14.0.0.tgz",
+            "integrity": "sha512-dapFZq8Kf+1X+6rWucy22qvGIPWR+yQZzjXMXg6RPq9LXrI94hdtUbLNzEf1KMFJO2+l2BkvLygZWAP4JZANyg==",
             "license": "MIT",
             "dependencies": {
                 "camelcase": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-sdk": "13.0.2",
+        "@doist/todoist-sdk": "14.0.0",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/tools/analyze-project-health.test.ts
+++ b/src/tools/analyze-project-health.test.ts
@@ -13,7 +13,6 @@ function createMockHealth(overrides: Partial<ProjectHealth> = {}): ProjectHealth
         status: 'ON_TRACK',
         description: null,
         descriptionSummary: null,
-        taskRecommendations: null,
         projectId: 'proj-123',
         updatedAt: new Date('2026-03-29T10:00:00Z'),
         isStale: false,

--- a/src/tools/get-project-health.test.ts
+++ b/src/tools/get-project-health.test.ts
@@ -33,7 +33,6 @@ function createMockHealth(overrides: Partial<ProjectHealth> = {}): ProjectHealth
         status: 'ON_TRACK',
         description: 'Project is progressing well.',
         descriptionSummary: 'On track',
-        taskRecommendations: null,
         projectId: 'proj-123',
         updatedAt: new Date('2026-03-28T10:00:00Z'),
         isStale: false,
@@ -259,30 +258,6 @@ describe('get-project-health tool', () => {
         expect(result.textContent).toContain('update is currently in progress')
         expect(result.structuredContent).toMatchObject({
             health: { updateInProgress: true },
-        })
-    })
-
-    it('should include task recommendations in output', async () => {
-        const recommendations = [
-            { taskId: 'task-1', recommendation: 'Break this task into subtasks' },
-            { taskId: 'task-2', recommendation: 'Set a due date' },
-        ]
-
-        mockTodoistApi.getProjectProgress.mockResolvedValue(createMockProgress())
-        mockTodoistApi.getProjectHealth.mockResolvedValue(
-            createMockHealth({ taskRecommendations: recommendations }),
-        )
-
-        const result = await getProjectHealth.execute(
-            { projectId: 'proj-123', includeContext: false },
-            mockTodoistApi,
-        )
-
-        expect(result.textContent).toContain('Task Recommendations')
-        expect(result.textContent).toContain('Break this task into subtasks')
-        expect(result.textContent).toContain('Set a due date')
-        expect(result.structuredContent).toMatchObject({
-            health: { taskRecommendations: recommendations },
         })
     })
 

--- a/src/tools/get-project-health.ts
+++ b/src/tools/get-project-health.ts
@@ -19,11 +19,6 @@ const ArgsSchema = {
         ),
 }
 
-const TaskRecommendationOutputSchema = z.object({
-    taskId: z.string().describe('The ID of the task this recommendation is for.'),
-    recommendation: z.string().describe('The recommendation for this task.'),
-})
-
 const TaskContextOutputSchema = z.object({
     id: z.string().describe('The task ID.'),
     content: z.string().describe('The task content/title.'),
@@ -55,10 +50,6 @@ const OutputSchema = {
                 .string()
                 .optional()
                 .describe('Brief summary of the health assessment.'),
-            taskRecommendations: z
-                .array(TaskRecommendationOutputSchema)
-                .optional()
-                .describe('Specific recommendations for individual tasks.'),
             isStale: z
                 .boolean()
                 .describe('Whether the health data is stale and may need refreshing.'),
@@ -156,15 +147,6 @@ function generateTextContent(
         lines.push(health.description)
     }
 
-    // Task recommendations
-    if (health.taskRecommendations && health.taskRecommendations.length > 0) {
-        lines.push('')
-        lines.push('## Task Recommendations')
-        for (const rec of health.taskRecommendations) {
-            lines.push(`- **Task ${rec.taskId}**: ${rec.recommendation}`)
-        }
-    }
-
     // Context (if included)
     if (context) {
         lines.push('')
@@ -198,7 +180,7 @@ function generateTextContent(
 const getProjectHealth = {
     name: ToolNames.GET_PROJECT_HEALTH,
     description:
-        'Get a comprehensive health assessment for a project including completion progress, health status (EXCELLENT, ON_TRACK, AT_RISK, CRITICAL), and optional detailed context with project metrics and task-level recommendations. Use includeContext=true for full detail including task data.',
+        'Get a comprehensive health assessment for a project including completion progress, health status (EXCELLENT, ON_TRACK, AT_RISK, CRITICAL), and optional detailed context with project metrics and task-level data. Use includeContext=true for that full detail.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: {
@@ -250,7 +232,6 @@ const getProjectHealth = {
                     status: data.health.status,
                     description: data.health.description ?? undefined,
                     descriptionSummary: data.health.descriptionSummary ?? undefined,
-                    taskRecommendations: data.health.taskRecommendations ?? undefined,
                     isStale: data.health.isStale,
                     updateInProgress: data.health.updateInProgress,
                     updatedAt: data.health.updatedAt?.toISOString(),


### PR DESCRIPTION
# Pull Request

## Short description

Bumps `@doist/todoist-sdk` to 14.0.0 and removes the last thing that depended on a field the API no longer returns.

Task recommendations were removed from project health in Doist/todoist#28902 (3 July), and the SDK dropped the field in Doist/todoist-sdk-typescript#662. `get-project-health` still declared `taskRecommendations` in its output schema, rendered a `## Task Recommendations` section that could never appear, and advertised "task-level recommendations" in its tool description — telling the model to expect advice this tool has no way to produce.

The SDK bump is a major, but the only breakage it surfaces is exactly this dead field: `tsc` failed in four places, all of them the code being deleted here. The test that asserted the recommendations rendering is deleted rather than replaced — there is nothing left to assert.

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

- [ ] Added tests for bugs / new features
- [ ] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.