### PR TITLE
feat!: migrate to MCP SDK v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This server includes `search` and `fetch` tools that follow the [OpenAI MCP spec
 
 ## Dependencies
 
-- MCP server using the official [@modelcontextprotocol/sdk](https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#installation)
+- MCP server using the official [@modelcontextprotocol/server](https://github.com/modelcontextprotocol/typescript-sdk)
 - Todoist Typescript API client [@doist/todoist-sdk](https://github.com/Doist/todoist-sdk)
 
 ## MCP Server Setup

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -35,6 +35,7 @@ For convenience, we also include a function that initializes an MCP Server with 
 
 ```js
 import { getMcpServer } from '@doist/todoist-mcp'
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio'
 
 async function main() {
     const server = getMcpServer({ todoistApiKey: process.env.TODOIST_API_KEY })

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
             },
             "devDependencies": {
                 "@anthropic-ai/sdk": "0.115.0",
+                "@modelcontextprotocol/client": "2.0.0",
                 "@modelcontextprotocol/inspector": "0.22.0",
                 "@semantic-release/changelog": "6.0.3",
                 "@semantic-release/exec": "7.1.0",
@@ -60,7 +61,8 @@
                 "npm": ">=11"
             },
             "peerDependencies": {
-                "@modelcontextprotocol/sdk": "^1.25.0"
+                "@modelcontextprotocol/node": "^2.0.0",
+                "@modelcontextprotocol/server": "^2.0.0"
             }
         },
         "node_modules/@actions/core": {
@@ -1180,6 +1182,37 @@
                 "resolve": "~1.22.2"
             }
         },
+        "node_modules/@modelcontextprotocol/client": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+            "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@modelcontextprotocol/core": "2.0.0",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "jose": "^6.1.3",
+                "pkce-challenge": "^5.0.0",
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@modelcontextprotocol/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+            "license": "MIT",
+            "dependencies": {
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/@modelcontextprotocol/ext-apps": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.2.2.tgz",
@@ -1424,6 +1457,28 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
+        "node_modules/@modelcontextprotocol/node": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+            "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@hono/node-server": "^1.19.9"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "@modelcontextprotocol/server": "^2.0.0",
+                "hono": "^4.11.4"
+            },
+            "peerDependenciesMeta": {
+                "hono": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.27.1",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
@@ -1462,6 +1517,20 @@
                 "zod": {
                     "optional": false
                 }
+            }
+        },
+        "node_modules/@modelcontextprotocol/server": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+            "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@modelcontextprotocol/core": "2.0.0",
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/@octokit/auth-token": {

--- a/package.json
+++ b/package.json
@@ -74,10 +74,12 @@
         "zod": "4.3.6"
     },
     "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.0"
+        "@modelcontextprotocol/node": "^2.0.0",
+        "@modelcontextprotocol/server": "^2.0.0"
     },
     "devDependencies": {
         "@anthropic-ai/sdk": "0.115.0",
+        "@modelcontextprotocol/client": "2.0.0",
         "@modelcontextprotocol/inspector": "0.22.0",
         "@semantic-release/changelog": "6.0.3",
         "@semantic-release/exec": "7.1.0",

--- a/src/http-app.ts
+++ b/src/http-app.ts
@@ -1,4 +1,4 @@
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node'
 import express, { type Express, type Request, type Response } from 'express'
 import { getMcpServer } from './mcp-server.js'
 import { requireTrustedHost } from './middleware/require-trusted-host.js'
@@ -41,7 +41,7 @@ function createHttpApp({ todoistApiKey, baseUrl, allowedHosts }: CreateHttpAppOp
         requireValidTodoistToken({ type: 'static', apiKey: todoistApiKey, baseUrl }),
         async (req: Request, res: Response) => {
             try {
-                const transport = new StreamableHTTPServerTransport({
+                const transport = new NodeStreamableHTTPServerTransport({
                     sessionIdGenerator: undefined,
                 })
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio'
 import dotenv from 'dotenv'
 import { getMcpServer } from './mcp-server.js'
 

--- a/src/mcp-apps/resources.test.ts
+++ b/src/mcp-apps/resources.test.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer } from '@modelcontextprotocol/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 describe('registerTaskListApp', () => {

--- a/src/mcp-apps/resources.ts
+++ b/src/mcp-apps/resources.ts
@@ -2,8 +2,9 @@ import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { RESOURCE_MIME_TYPE, registerAppResource } from '@modelcontextprotocol/ext-apps/server'
-import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { RESOURCE_MIME_TYPE } from '@modelcontextprotocol/ext-apps/server'
+import { ResourceTemplate } from '@modelcontextprotocol/server'
+import type { McpServer } from '@modelcontextprotocol/server'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const TASK_LIST_HTML_PATHS = [
@@ -74,12 +75,12 @@ function createTaskListResourceResult(uri: string) {
  * Register the task list MCP App resource on the server.
  */
 function registerTaskListApp(server: McpServer) {
-    registerAppResource(
-        server,
+    server.registerResource(
         'todoist-task-list',
         taskListResourceUri,
         {
             description: taskListResourceDescription,
+            mimeType: RESOURCE_MIME_TYPE,
             _meta: taskListResourceMeta,
         },
         async () => createTaskListResourceResult(taskListResourceUri),

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -1,6 +1,7 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
-import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
+import type { ContentBlock } from '@modelcontextprotocol/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
 import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
 import { addTasks } from './tools/add-tasks.js'
 
@@ -116,7 +117,7 @@ describe('registerTool config', () => {
 
     it('includes outputSchema when the tool declares one', () => {
         const { mock, server, client } = captureRegisterToolMock()
-        const outputSchema = {}
+        const outputSchema = { value: z.string() }
 
         registerTool({
             tool: buildToolFixture({
@@ -130,7 +131,9 @@ describe('registerTool config', () => {
         })
 
         const config = mock.mock.calls[0]?.[1] as Record<string, unknown>
-        expect(config.outputSchema).toBe(outputSchema)
+        expect(config.inputSchema).toBeInstanceOf(z.ZodObject)
+        expect(config.outputSchema).toBeInstanceOf(z.ZodObject)
+        expect((config.outputSchema as z.ZodObject).shape).toHaveProperty('value')
     })
 })
 

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -1,8 +1,11 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
-import { registerAppTool } from '@modelcontextprotocol/ext-apps/server'
-import type { McpServer, ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
-import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
-import type { z } from 'zod'
+import type {
+    McpServer,
+    ToolCallback,
+    ContentBlock,
+    ToolAnnotations,
+} from '@modelcontextprotocol/server'
+import { z } from 'zod'
 import type { AnyTodoistTool, ExecuteResult } from './todoist-tool.js'
 import { formatToolExecutionError } from './tool-execution-error.js'
 import { runWithUsageTrackingContext } from './usage-tracking.js'
@@ -179,6 +182,25 @@ function hasAppUiMeta(meta: Record<string, unknown> | undefined): meta is AppToo
     return typeof meta.ui === 'object' && meta.ui !== null
 }
 
+function normalizeAppToolMeta(meta: AppToolMeta): Record<string, unknown> {
+    const ui =
+        typeof meta.ui === 'object' && meta.ui !== null
+            ? (meta.ui as Record<string, unknown>)
+            : undefined
+    const resourceUri = ui?.resourceUri
+    const legacyResourceUri = meta['ui/resourceUri']
+
+    if (typeof resourceUri === 'string' && typeof legacyResourceUri !== 'string') {
+        return { ...meta, 'ui/resourceUri': resourceUri }
+    }
+
+    if (typeof legacyResourceUri === 'string' && typeof resourceUri !== 'string') {
+        return { ...meta, ui: { ...ui, resourceUri: legacyResourceUri } }
+    }
+
+    return meta
+}
+
 /**
  * Tools that expose user emails in their outputs.
  * When adding new tools that return user emails, update this list
@@ -258,12 +280,15 @@ function registerTool({
         client: TodoistApi,
     ) => ExecuteResult<z.ZodRawShape>
 
+    const inputSchema = z.object(tool.parameters)
+    const outputSchema = tool.outputSchema ? z.object(tool.outputSchema) : undefined
+
     // `getToolOutput` assembles its result incrementally and so is typed as a
     // plain record, which does not structurally match `CallToolResult` (that
     // requires `content`). The values it produces are valid results; only the
     // static shape is looser.
     // @ts-expect-error see above
-    const cb: ToolCallback<z.ZodRawShape> = async (args, _context) => {
+    const cb: ToolCallback<typeof inputSchema> = async (args, _context) => {
         try {
             let { textContent, structuredContent, contentItems } =
                 await runWithUsageTrackingContext(tool.name, () =>
@@ -289,23 +314,12 @@ function registerTool({
 
     const toolConfig = {
         description: tool.description,
-        inputSchema: tool.parameters,
-        ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+        inputSchema,
+        ...(outputSchema ? { outputSchema } : {}),
         annotations: getMcpAnnotations(tool),
-        ...(tool._meta ? { _meta: tool._meta } : {}),
-    }
-
-    if (hasAppUiMeta(tool._meta)) {
-        registerAppTool(
-            server,
-            tool.name,
-            {
-                ...toolConfig,
-                _meta: tool._meta,
-            },
-            cb,
-        )
-        return
+        ...(tool._meta
+            ? { _meta: hasAppUiMeta(tool._meta) ? normalizeAppToolMeta(tool._meta) : tool._meta }
+            : {}),
     }
 
     server.registerTool(tool.name, toolConfig, cb)

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,5 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-
+import { McpServer } from '@modelcontextprotocol/server'
 import { registerTaskListApp } from './mcp-apps/resources.js'
 import {
     FEATURE_NAMES,

--- a/src/prompts/productivity-analysis.test.ts
+++ b/src/prompts/productivity-analysis.test.ts
@@ -1,4 +1,4 @@
-import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js'
+import type { GetPromptResult } from '@modelcontextprotocol/server'
 import { buildPromptText, computeDateRange, productivityAnalysis } from './productivity-analysis.js'
 
 function getPromptText(result: GetPromptResult): string {

--- a/src/prompts/productivity-analysis.ts
+++ b/src/prompts/productivity-analysis.ts
@@ -1,7 +1,7 @@
-import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js'
+import type { GetPromptResult } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 
-const argsSchema = {
+const argsSchema = z.object({
     period: z
         .enum(['today', '7d', '14d', '30d', 'this-week', 'this-month'])
         .default('7d')
@@ -18,9 +18,9 @@ const argsSchema = {
         .string()
         .optional()
         .describe('Optional project ID to scope the analysis to a specific project.'),
-}
+})
 
-type PromptArgs = z.infer<z.ZodObject<typeof argsSchema>>
+type PromptArgs = z.infer<typeof argsSchema>
 
 /**
  * Compute the date range (since/until as YYYY-MM-DD) for a given period.

--- a/src/todoist-tool.ts
+++ b/src/todoist-tool.ts
@@ -1,5 +1,5 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
-import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/sdk/types.js'
+import type { ContentBlock, ToolAnnotations } from '@modelcontextprotocol/server'
 import type { z } from 'zod'
 
 type ExecuteResult<Output extends z.ZodRawShape> = Promise<{

--- a/src/token-footprint.test.ts
+++ b/src/token-footprint.test.ts
@@ -6,12 +6,11 @@ import { instructions } from './mcp-server.js'
 import type { AnyTodoistTool } from './todoist-tool.js'
 import { registeredTools } from './tool-registry.js'
 
-// The SDK serializes tool schemas with these options; see `toJsonSchemaCompat`
-// in @modelcontextprotocol/sdk's server/mcp.js. Zod defaults `io` to 'output',
-// which measures a schema the wire never carries — for tools using `.pipe()`
-// that can be several times the real cost. Keep these in step with the SDK.
-const INPUT_SCHEMA_OPTIONS = { unrepresentable: 'any', io: 'input', target: 'draft-7' } as const
-const OUTPUT_SCHEMA_OPTIONS = { unrepresentable: 'any', io: 'output', target: 'draft-7' } as const
+// SDK v2 serializes Standard Schemas as JSON Schema 2020-12. Zod defaults `io`
+// to 'output', which measures a schema the wire never carries — for tools using
+// `.pipe()` that can be several times the real cost. Keep these in step with the SDK.
+const INPUT_SCHEMA_OPTIONS = { io: 'input', target: 'draft-2020-12' } as const
+const OUTPUT_SCHEMA_OPTIONS = { io: 'output', target: 'draft-2020-12' } as const
 
 function tokens(text: string): number {
     return encode(text).length
@@ -26,8 +25,8 @@ function formatToolTitle(name: string): string {
 }
 
 /**
- * Mirror of the `_meta` normalisation `registerAppTool` applies, which fills in
- * whichever of the two widget resource-URI spellings the tool did not declare.
+ * Mirror of the `_meta` normalisation in `registerTool`, which fills in whichever
+ * of the two widget resource-URI spellings the tool did not declare.
  */
 function normalizeAppUiMeta(meta: Record<string, unknown>): Record<string, unknown> {
     const ui = meta.ui as { resourceUri?: string } | undefined

--- a/src/tool-schema-dialect.test.ts
+++ b/src/tool-schema-dialect.test.ts
@@ -1,0 +1,31 @@
+import { Client, InMemoryTransport } from '@modelcontextprotocol/client'
+import { describe, expect, it } from 'vitest'
+import { getMcpServer } from './mcp-server.js'
+import { registeredTools } from './tool-registry.js'
+
+const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema'
+
+describe('advertised tool schema dialects', () => {
+    it('uses JSON Schema 2020-12 for every tool schema', async () => {
+        const server = getMcpServer({ todoistApiKey: 'test-token' })
+        const client = new Client({ name: 'schema-dialect-test', version: '1.0.0' })
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+        await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+        try {
+            const { tools } = await client.listTools()
+
+            expect(tools).toHaveLength(registeredTools.length)
+            for (const tool of tools) {
+                expect(tool.inputSchema.$schema).toBe(JSON_SCHEMA_2020_12)
+                if (tool.outputSchema) {
+                    expect(tool.outputSchema.$schema).toBe(JSON_SCHEMA_2020_12)
+                }
+            }
+        } finally {
+            await client.close()
+            await server.close()
+        }
+    })
+})

--- a/src/tools/tool-annotations.test.ts
+++ b/src/tools/tool-annotations.test.ts
@@ -1,4 +1,4 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer } from '@modelcontextprotocol/server'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { getMcpServer } from '../mcp-server.js'
 import { ToolNames } from '../utils/tool-names.js'

--- a/src/tools/view-attachment.ts
+++ b/src/tools/view-attachment.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from '@modelcontextprotocol/sdk/types.js'
+import type { ContentBlock } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { ToolNames } from '../utils/tool-names.js'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,8 @@ export default defineConfig({
         rollupOptions: {
             // Externalize dependencies to avoid bundling them
             external: [
-                '@modelcontextprotocol/sdk',
+                '@modelcontextprotocol/node',
+                '@modelcontextprotocol/server',
                 '@doist/todoist-sdk',
                 'date-fns',
                 'dotenv',


### PR DESCRIPTION
> [!WARNING]
> This is a breaking change. 

## Summary

- migrate the MCP server and transports to the split MCP TypeScript SDK v2 packages
- register tools and prompts with Standard Schema objects
- preserve MCP Apps metadata using native v2 registration while ext-apps remains typed against SDK v1
- update token-footprint measurement and public setup documentation
- add a regression test that requires JSON Schema 2020-12 on every advertised tool schema

## Why

SDK v1 emits explicit draft-07 tool schemas. Some MCP clients reject those schemas because they validate tools as JSON Schema 2020-12. SDK v2 emits 2020-12 schemas natively, so this fixes the compatibility issue without a schema-rewriting workaround.

This is a breaking library change because getMcpServer now returns the v2 McpServer type and the peer dependencies move from @modelcontextprotocol/sdk to @modelcontextprotocol/server and @modelcontextprotocol/node.

## Verification

- 47 input schemas and 46 output schemas advertise JSON Schema 2020-12
- all 93 schemas compile with an Ajv 2020-12 validator
- npm test: 74 files, 1180 tests passed
- npm run check
- npm run type-check
- npm run test:executable
