### PR TITLE
feat(filters): expose filter descriptions in the filter tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "13.1.3",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-sdk": "15.0.0",
+                "@doist/todoist-sdk": "15.1.0",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -507,9 +507,9 @@
             "license": "MIT"
         },
         "node_modules/@doist/todoist-sdk": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.0.tgz",
-            "integrity": "sha512-GN1WNG/smkjyo8f6HfAfM5cdR1TuBFheN87by/03SM6cBAIs6L71nlf6EM9srskAn4gM0kpCggEkgCADSoiOAg==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.1.0.tgz",
+            "integrity": "sha512-qKtCpzCyf5e/2u6Xqz1c7dukzOInPsA6nz46eka7N5til9Lnl1KnmSo8882D86zHC7nqmUd89eqtHQzBE+L6vg==",
             "license": "MIT",
             "dependencies": {
                 "@doist/sdk-kmp": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-sdk": "15.0.0",
+        "@doist/todoist-sdk": "15.1.0",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/tools/add-filters.test.ts
+++ b/src/tools/add-filters.test.ts
@@ -1,5 +1,6 @@
 import type { Filter, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { z } from 'zod'
 import { TEST_ERRORS } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { addFilters } from './add-filters.js'
@@ -130,6 +131,85 @@ describe(`${ADD_FILTERS} tool`, () => {
             })
 
             expect(result.structuredContent.filters[0]?.isFavorite).toBe(true)
+        })
+    })
+
+    describe('descriptions', () => {
+        function mockCreateEchoingDescription() {
+            mockTodoistApi.sync.mockImplementation(async (request) => {
+                const commands = request.commands ?? []
+                const tempIdMap: Record<string, string> = {}
+                const createdFilters: Filter[] = []
+                for (const cmd of commands) {
+                    if (cmd.type === 'filter_add' && cmd.tempId) {
+                        const newId = 'filter-described'
+                        tempIdMap[cmd.tempId] = newId
+                        createdFilters.push(
+                            createMockFilter({
+                                id: newId,
+                                name: cmd.args.name as string,
+                                query: cmd.args.query as string,
+                                // Echo back whatever the command carried, the way the API would.
+                                description: cmd.args.description as string | undefined,
+                            }),
+                        )
+                    }
+                }
+                return { filters: createdFilters, tempIdMapping: tempIdMap }
+            })
+        }
+
+        it('sends the description and echoes it back', async () => {
+            mockCreateEchoingDescription()
+
+            const result = await addFilters.execute(
+                {
+                    filters: [
+                        {
+                            name: 'Day job',
+                            query: 'today & #Work',
+                            description: 'Everything for the day job',
+                        },
+                    ],
+                },
+                mockTodoistApi,
+            )
+
+            const syncCall = mockTodoistApi.sync.mock.calls[0]?.[0]
+            expect(syncCall?.commands?.[0]?.args).toMatchObject({
+                description: 'Everything for the day job',
+            })
+            expect(result.structuredContent.filters[0]?.description).toBe(
+                'Everything for the day job',
+            )
+        })
+
+        it('leaves the key out of the command and the output when there is no description', async () => {
+            mockCreateEchoingDescription()
+
+            const result = await addFilters.execute(
+                { filters: [{ name: 'Day job', query: 'today & #Work' }] },
+                mockTodoistApi,
+            )
+
+            const syncCall = mockTodoistApi.sync.mock.calls[0]?.[0]
+            expect(syncCall?.commands?.[0]?.args).not.toHaveProperty('description')
+            expect(result.structuredContent.filters[0]).not.toHaveProperty('description')
+        })
+
+        it('drops an empty description rather than sending one', async () => {
+            mockCreateEchoingDescription()
+
+            // The schema normalizes "" to undefined, so the key never reaches the command.
+            // LLMs send "" for omitted optional fields and the API rejects that.
+            const parsed = z.object(addFilters.parameters).parse({
+                filters: [{ name: 'Day job', query: 'today & #Work', description: '' }],
+            })
+            const result = await addFilters.execute(parsed, mockTodoistApi)
+
+            const syncCall = mockTodoistApi.sync.mock.calls[0]?.[0]
+            expect(syncCall?.commands?.[0]?.args).not.toHaveProperty('description')
+            expect(result.structuredContent.filters[0]).not.toHaveProperty('description')
         })
     })
 

--- a/src/tools/add-filters.ts
+++ b/src/tools/add-filters.ts
@@ -2,6 +2,7 @@ import { type ColorKey, createCommand } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { ColorOutputSchema, ColorSchema } from '../utils/colors.js'
+import { optionalString } from '../utils/schema-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { FilterOutputSchema } from './find-filters.js'
 
@@ -14,10 +15,7 @@ const FilterSchema = z.object({
             'The filter query string. Examples: "today & p1", "#Work & overdue", "@email & today", "(p1 | p2) & !assigned". ' +
                 'Operators: | (OR), & (AND), ! (NOT), () grouping, , (multiple queries).',
         ),
-    description: z
-        .string()
-        .optional()
-        .describe('A markdown description explaining what the filter is for.'),
+    description: optionalString('A markdown description explaining what the filter is for.'),
     color: ColorSchema,
     isFavorite: z
         .boolean()

--- a/src/tools/add-filters.ts
+++ b/src/tools/add-filters.ts
@@ -14,6 +14,10 @@ const FilterSchema = z.object({
             'The filter query string. Examples: "today & p1", "#Work & overdue", "@email & today", "(p1 | p2) & !assigned". ' +
                 'Operators: | (OR), & (AND), ! (NOT), () grouping, , (multiple queries).',
         ),
+    description: z
+        .string()
+        .optional()
+        .describe('A markdown description explaining what the filter is for.'),
     color: ColorSchema,
     isFavorite: z
         .boolean()
@@ -49,6 +53,9 @@ const addFilters = {
                 {
                     name: filter.name,
                     query: filter.query,
+                    ...(filter.description !== undefined
+                        ? { description: filter.description }
+                        : {}),
                     ...(filter.color !== undefined ? { color: filter.color as ColorKey } : {}),
                     ...(filter.isFavorite !== undefined ? { isFavorite: filter.isFavorite } : {}),
                 },
@@ -73,6 +80,10 @@ const addFilters = {
                     id: realId,
                     name: filter.name,
                     query: filter.query,
+                    // Omitted rather than null when absent: structured content is sanitised
+                    // with `removeNullFields`, so a null would be stripped and then fail
+                    // validation against the declared output schema.
+                    ...(filter.description ? { description: filter.description } : {}),
                     color: outputColor,
                     isFavorite: filter.isFavorite ?? false,
                     itemOrder: 0,

--- a/src/tools/find-filters.test.ts
+++ b/src/tools/find-filters.test.ts
@@ -196,6 +196,39 @@ describe(`${FIND_FILTERS} tool`, () => {
         })
     })
 
+    describe('descriptions', () => {
+        it('returns a description that has one', async () => {
+            mockTodoistApi.sync.mockResolvedValue({
+                filters: [createMockFilter({ description: 'Everything for the day job' })],
+            })
+
+            const result = await findFilters.execute({}, mockTodoistApi)
+
+            expect(result.structuredContent.filters[0]?.description).toBe(
+                'Everything for the day job',
+            )
+        })
+
+        // The column is nullable and the sync view normalizes NULL to "" on the way out, so a
+        // filter with no description arrives as either, and a payload predating the field has
+        // no key at all. All three have to surface as undefined rather than null: structured
+        // content is sanitised with removeNullFields, so a null would be stripped and then
+        // fail validation against the optional output schema.
+        it.each([
+            ['an empty string', ''],
+            ['a null', null],
+            ['no key at all', undefined],
+        ])('surfaces no description for %s', async (_label, description) => {
+            mockTodoistApi.sync.mockResolvedValue({
+                filters: [createMockFilter({ description } as Partial<Filter>)],
+            })
+
+            const result = await findFilters.execute({}, mockTodoistApi)
+
+            expect(result.structuredContent.filters[0]?.description).toBeUndefined()
+        })
+    })
+
     describe('error handling', () => {
         it('should propagate API errors', async () => {
             mockTodoistApi.sync.mockRejectedValue(new Error(TEST_ERRORS.API_UNAUTHORIZED))

--- a/src/tools/find-filters.ts
+++ b/src/tools/find-filters.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { ColorOutputSchema } from '../utils/colors.js'
+import { readFilterDescription } from '../utils/filter-description.js'
 import { ToolNames } from '../utils/tool-names.js'
 
 const ArgsSchema = {
@@ -16,6 +17,12 @@ const FilterOutputSchema = z.object({
     id: z.string().describe('The unique ID of the filter.'),
     name: z.string().describe('The name of the filter.'),
     query: z.string().describe('The filter query string (e.g. "today & p1", "#Work & overdue").'),
+    description: z
+        .string()
+        .optional()
+        .describe(
+            'A markdown description explaining what the filter is for. Omitted when the filter has none.',
+        ),
     color: ColorOutputSchema,
     isFavorite: z.boolean().describe('Whether the filter is marked as favorite.'),
     itemOrder: z.number().describe('The display order of the filter.'),
@@ -48,6 +55,7 @@ const findFilters = {
             id: f.id,
             name: f.name,
             query: f.query,
+            description: readFilterDescription(f),
             color: ColorOutputSchema.parse(f.color),
             isFavorite: f.isFavorite,
             itemOrder: f.itemOrder,

--- a/src/tools/update-filters.test.ts
+++ b/src/tools/update-filters.test.ts
@@ -78,6 +78,39 @@ describe(`${UPDATE_FILTERS} tool`, () => {
             expect(result.structuredContent.totalCount).toBe(1)
         })
 
+        it('should update a filter description', async () => {
+            const updatedFilter = createMockFilter({ id: 'filter-1' })
+            mockTodoistApi.sync.mockResolvedValue({ filters: [updatedFilter] })
+
+            await updateFilters.execute(
+                { filters: [{ id: 'filter-1', description: 'Everything due this week' }] },
+                mockTodoistApi,
+            )
+
+            const commandCall = mockTodoistApi.sync.mock.calls[0]?.[0]
+            expect(commandCall?.commands?.[0]?.args).toMatchObject({
+                id: 'filter-1',
+                description: 'Everything due this week',
+            })
+        })
+
+        it('should clear a description when passed "remove"', async () => {
+            const updatedFilter = createMockFilter({ id: 'filter-1' })
+            mockTodoistApi.sync.mockResolvedValue({ filters: [updatedFilter] })
+
+            await updateFilters.execute(
+                { filters: [{ id: 'filter-1', description: 'remove' }] },
+                mockTodoistApi,
+            )
+
+            // The sentinel becomes null, which is what the API reads as "clear it".
+            const commandCall = mockTodoistApi.sync.mock.calls[0]?.[0]
+            expect(commandCall?.commands?.[0]?.args).toMatchObject({
+                id: 'filter-1',
+                description: null,
+            })
+        })
+
         it('should update isFavorite status', async () => {
             const updatedFilter = createMockFilter({ id: 'filter-1', isFavorite: true })
             mockTodoistApi.sync.mockResolvedValue({ filters: [updatedFilter] })

--- a/src/tools/update-filters.test.ts
+++ b/src/tools/update-filters.test.ts
@@ -1,5 +1,6 @@
 import type { Filter, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { z } from 'zod'
 import { TEST_ERRORS } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { updateFilters } from './update-filters.js'
@@ -92,6 +93,17 @@ describe(`${UPDATE_FILTERS} tool`, () => {
                 id: 'filter-1',
                 description: 'Everything due this week',
             })
+        })
+
+        it('accepts a legacy null as the clear sentinel', () => {
+            // Callers that predate the "remove" sentinel clear optional fields with null.
+            // The schema turns it into the sentinel so those calls keep working, and the
+            // command builder then sends the null the API expects.
+            const parsed = z.object(updateFilters.parameters).parse({
+                filters: [{ id: 'filter-1', description: null }],
+            })
+
+            expect(parsed.filters[0]?.description).toBe('remove')
         })
 
         it('should clear a description when passed "remove"', async () => {

--- a/src/tools/update-filters.ts
+++ b/src/tools/update-filters.ts
@@ -2,6 +2,7 @@ import { type ColorKey, createCommand } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { ColorOutputSchema, ColorSchema } from '../utils/colors.js'
+import { readFilterDescription } from '../utils/filter-description.js'
 import { ToolNames } from '../utils/tool-names.js'
 import { FilterOutputSchema } from './find-filters.js'
 
@@ -14,6 +15,12 @@ const FilterUpdateSchema = z.object({
         .optional()
         .describe(
             'The new filter query string. Examples: "today & p1", "#Work & overdue", "@email & today".',
+        ),
+    description: z
+        .string()
+        .optional()
+        .describe(
+            'A markdown description explaining what the filter is for. Use "remove" to clear the description; omit the field to leave it unchanged.',
         ),
     color: ColorSchema,
     isFavorite: z.boolean().optional().describe('Whether to mark the filter as a favorite.'),
@@ -74,10 +81,14 @@ const updateFilters = {
         }
 
         const commands = toUpdate.map((filter) => {
-            const { id, color, ...otherArgs } = filter
+            const { id, color, description, ...otherArgs } = filter
             return createCommand('filter_update', {
                 id,
                 ...otherArgs,
+                // "remove" is the house sentinel for clearing a field; the API clears on null.
+                ...(description !== undefined
+                    ? { description: description === 'remove' ? null : description }
+                    : {}),
                 ...(color !== undefined ? { color: color as ColorKey } : {}),
             })
         })
@@ -94,6 +105,7 @@ const updateFilters = {
                 id: f.id,
                 name: f.name,
                 query: f.query,
+                description: readFilterDescription(f),
                 color: ColorOutputSchema.parse(f.color),
                 isFavorite: f.isFavorite,
                 itemOrder: f.itemOrder,

--- a/src/tools/update-filters.ts
+++ b/src/tools/update-filters.ts
@@ -17,11 +17,16 @@ const FilterUpdateSchema = z.object({
             'The new filter query string. Examples: "today & p1", "#Work & overdue", "@email & today".',
         ),
     description: z
-        .string()
-        .optional()
-        .describe(
-            'A markdown description explaining what the filter is for. Use "remove" to clear the description; omit the field to leave it unchanged.',
-        ),
+        .preprocess(
+            // Keep accepting legacy null while exposing a Gemini-compatible string schema.
+            (value) => (value === null ? 'remove' : value),
+            z
+                .string()
+                .describe(
+                    'A markdown description explaining what the filter is for. Use "remove" to clear the description; omit the field to leave it unchanged.',
+                ),
+        )
+        .optional(),
     color: ColorSchema,
     isFavorite: z.boolean().optional().describe('Whether to mark the filter as a favorite.'),
 })

--- a/src/utils/filter-description.ts
+++ b/src/utils/filter-description.ts
@@ -1,23 +1,16 @@
 /**
- * Reads a filter's description off a sync payload.
+ * Normalizes a filter's description for structured output.
  *
- * `FilterSchema` in the published SDK is a loose object that does not declare
- * `description`, so the field arrives typed as `unknown`. This narrows it in one
- * place instead of casting at each call site.
+ * A filter with no description can arrive as either `null` or `""`: the column is
+ * nullable, and the sync view normalizes NULL to an empty string on the way out.
+ * Both mean the same thing, so both collapse to `undefined` here.
  *
- * Returns `undefined` rather than `null` for a filter with no description, so
- * the key can be left out of `structuredContent` entirely. Structured content is
- * sanitised with `removeNullFields` on the way out, so a null would be stripped
- * and fail validation against the declared output schema.
- *
- * The backend sends `""` for a filter with no description: the column is
- * nullable but the sync view normalizes NULL on the way out. Both are treated as
- * absent here.
- *
- * Delete this once `@doist/todoist-sdk` carries `description` on its filter
- * types, and read `filter.description` directly.
+ * Returning `undefined` rather than `null` matters. Structured content is sanitised
+ * with `removeNullFields` on the way out, so a null would be stripped from the payload
+ * and then fail validation against the declared output schema, which is optional
+ * rather than nullable.
  */
-export function readFilterDescription(filter: Record<string, unknown>): string | undefined {
-    const description = filter.description
-    return typeof description === 'string' && description.length > 0 ? description : undefined
+export function readFilterDescription(filter: { description?: string | null }): string | undefined {
+    // `||` not `??`: an empty string has to collapse too, not just null.
+    return filter.description || undefined
 }

--- a/src/utils/filter-description.ts
+++ b/src/utils/filter-description.ts
@@ -1,0 +1,23 @@
+/**
+ * Reads a filter's description off a sync payload.
+ *
+ * `FilterSchema` in the published SDK is a loose object that does not declare
+ * `description`, so the field arrives typed as `unknown`. This narrows it in one
+ * place instead of casting at each call site.
+ *
+ * Returns `undefined` rather than `null` for a filter with no description, so
+ * the key can be left out of `structuredContent` entirely. Structured content is
+ * sanitised with `removeNullFields` on the way out, so a null would be stripped
+ * and fail validation against the declared output schema.
+ *
+ * The backend sends `""` for a filter with no description: the column is
+ * nullable but the sync view normalizes NULL on the way out. Both are treated as
+ * absent here.
+ *
+ * Delete this once `@doist/todoist-sdk` carries `description` on its filter
+ * types, and read `filter.description` directly.
+ */
+export function readFilterDescription(filter: Record<string, unknown>): string | undefined {
+    const description = filter.description
+    return typeof description === 'string' && description.length > 0 ? description : undefined
+}


### PR DESCRIPTION
# Pull Request

## Short description

Filters are getting descriptions, so the filter tools can read and write them. `add-filters` sets one, `update-filters` changes or clears it, `find-filters` returns it.

- Clearing uses `"remove"` rather than null, matching how `update-tasks` clears a due date. The schema lint rejects nullable optional strings because they break the Gemini API.
- `readFilterDescription` is scaffolding. Delete it once the SDK PR lands and the field is properly typed.
- Blocked on Doist/todoist-sdk-typescript#668.

Backend: Doist/Todoist#29669

## PR Checklist

-   [x] Added tests for bugs / new features
-   [ ] Updated docs (README, etc.)
-   [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

No new tools, so no registration or export changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
