### PR TITLE
feat: take todoist-sdk 15 and read template IDs with it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "12.6.0",
             "license": "MIT",
             "dependencies": {
-                "@doist/todoist-sdk": "14.0.1",
+                "@doist/todoist-sdk": "15.0.0",
                 "@modelcontextprotocol/ext-apps": "1.2.2",
                 "date-fns": "4.1.0",
                 "dompurify": "3.3.3",
@@ -498,17 +498,23 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@doist/sdk-kmp": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@doist/sdk-kmp/-/sdk-kmp-0.2.3.tgz",
+            "integrity": "sha512-6V1vuu80nEhIOKDQ117kPICZJpTgYbsdIL1AiGQbAPVFkNJYLZAWG5JXqmNrVBzAwq7LF+f/47C/NZX4pzNjdw==",
+            "license": "MIT"
+        },
         "node_modules/@doist/todoist-sdk": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-14.0.1.tgz",
-            "integrity": "sha512-l2mXCZHFkKWHyVeqGj9dZONAyOLCP5Qy89msUH4/45SDfubpFN+lx6D5Q52w2Qkc8sy6nV8rnTR7E6U7jS9myg==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/@doist/todoist-sdk/-/todoist-sdk-15.0.0.tgz",
+            "integrity": "sha512-GN1WNG/smkjyo8f6HfAfM5cdR1TuBFheN87by/03SM6cBAIs6L71nlf6EM9srskAn4gM0kpCggEkgCADSoiOAg==",
             "license": "MIT",
             "dependencies": {
+                "@doist/sdk-kmp": "0.2.3",
                 "camelcase": "6.3.0",
                 "emoji-regex": "10.6.0",
-                "form-data": "4.0.6",
                 "ts-custom-error": "^3.2.0",
-                "undici": "7.24.8",
+                "undici": "^7.29.0",
                 "uuid": "11.1.1",
                 "zod": "4.3.6"
             },
@@ -5293,12 +5299,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-            "license": "MIT"
-        },
         "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -6023,18 +6023,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "license": "MIT",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/commander": {
             "version": "14.0.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
@@ -6451,15 +6439,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6802,21 +6781,6 @@
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-set-tostringtag": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-            "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-            "license": "MIT",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "get-intrinsic": "^1.2.6",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -7260,43 +7224,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/form-data": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.4",
-                "mime-types": "^2.1.35"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/form-data/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/form-data/node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "license": "MIT",
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/formdata-polyfill": {
             "version": "4.0.10",
             "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -7600,21 +7527,6 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "license": "MIT",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "license": "MIT",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -14358,9 +14270,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.24.8",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-            "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
         "prepare": "husky"
     },
     "dependencies": {
-        "@doist/todoist-sdk": "14.0.1",
+        "@doist/todoist-sdk": "15.0.0",
         "@modelcontextprotocol/ext-apps": "1.2.2",
         "date-fns": "4.1.0",
         "dompurify": "3.3.3",

--- a/src/tools/import-project-template.ts
+++ b/src/tools/import-project-template.ts
@@ -1,3 +1,4 @@
+import { parseTodoistUrl } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
 import { mapComment, mapTask } from '../tool-helpers.js'
@@ -37,19 +38,17 @@ function extractTemplateId(input: string): string {
         )
     }
 
-    const segments = url.pathname.split('/').filter(Boolean)
-    if (!segments.includes('templates')) {
+    // The SDK recognises a fixed set of Todoist hosts, which is narrower than
+    // the subdomains accepted above, so point the URL at the canonical host
+    // before reading the template ID out of the path.
+    url.hostname = 'todoist.com'
+
+    const parsed = parseTodoistUrl(url.toString())
+    if (parsed?.type !== 'template') {
         throw new Error(`"${trimmed}" is not a Todoist template URL.`)
     }
 
-    const last = segments.at(-1)
-    const id = last === 'view' ? segments.at(-2) : last
-
-    if (!id) {
-        throw new Error(`Could not read a template ID from "${trimmed}".`)
-    }
-
-    return id
+    return parsed.id
 }
 
 function isTodoistHost(hostname: string): boolean {


### PR DESCRIPTION
## What

Takes `@doist/todoist-sdk` 15.0.0, which is ESM-only and moves URL generation into the shared link rules (backed by `@doist/sdk-kmp`).

The server already builds its entity links with `getTaskUrl` / `getProjectUrl`, so there was little to consolidate. The one piece that was still hand-rolled is template URL parsing.

## Template URLs

`extractTemplateId` walked path segments looking for `templates` and special-cased a trailing `/view`. It now hands the URL to the SDK parser, which recognises template links (`/templates/{id}`, with or without `/view`, and the `/app/templates/{id}` form) as part of the shared rules.

The host check stays local, deliberately: it accepts **any** `todoist.com` subdomain, which is broader than the parser's fixed host set. Gallery links are commonly on `www.todoist.com`, which the parser does not recognise, so the URL is pointed at the canonical host before parsing. Without that, three existing tests covering `www` gallery URLs regress.

Bare template IDs still pass straight through, and both error messages ("not a Todoist domain" vs "is not a Todoist template URL") are unchanged.

## Not changed

`TODOIST_APP_URL` in `mcp-apps/task-list/app.tsx` stays a local constant. It is the app root rather than an entity link, the SDK has no builder for it, and that file is bundled for the browser — pulling the SDK in for one constant would add roughly 45 KB gzipped to a client bundle.

## Verification

1210 tests pass, `type-check`, `check` and `build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)