### PR TITLE
fix: align get-overview section output schema

### DIFF
--- a/src/tools/get-overview.test.ts
+++ b/src/tools/get-overview.test.ts
@@ -1,5 +1,6 @@
 import type { PersonalProject, Section, Task, TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, vi } from 'vitest'
+import { z } from 'zod'
 import { removeNullFields } from '../utils/sanitize-data.js'
 import {
     createMockProject,
@@ -10,7 +11,7 @@ import {
     TEST_IDS,
 } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
-import { getOverview } from './get-overview.js'
+import { type AccountOverviewStructured, getOverview } from './get-overview.js'
 
 // Mock the Todoist API
 const mockTodoistApi = {
@@ -73,7 +74,7 @@ describe(`${GET_OVERVIEW} tool`, () => {
             expect(result.textContent).toMatchSnapshot()
 
             // Test structured content sanity checks
-            const structuredContent = result.structuredContent
+            const structuredContent = result.structuredContent as AccountOverviewStructured
             expect(structuredContent).toEqual(
                 expect.objectContaining({
                     type: 'account_overview',
@@ -89,6 +90,15 @@ describe(`${GET_OVERVIEW} tool`, () => {
                 }),
             )
             expect(structuredContent.projects).toHaveLength(1) // Only non-inbox projects
+            expect(structuredContent.projects[0]?.sections).toEqual([
+                expect.objectContaining({
+                    id: TEST_IDS.SECTION_1,
+                    sectionOrder: 1,
+                }),
+            ])
+            expect(() =>
+                z.object(getOverview.outputSchema).parse(removeNullFields(structuredContent)),
+            ).not.toThrow()
         })
 
         it('should produce structured content that survives removeNullFields sanitization', async () => {

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -27,7 +27,7 @@ const ProjectStructureSchema: z.ZodType<{
     parentId?: string
     folderId?: string
     childOrder: number
-    sections: { id: string; name: string }[]
+    sections: SectionSummary[]
     children: unknown[]
 }> = z.lazy(() =>
     z.object({
@@ -42,12 +42,7 @@ const ProjectStructureSchema: z.ZodType<{
             .optional()
             .describe('The folder ID this project belongs to (workspace projects only).'),
         childOrder: z.number().describe('The ordering index among siblings.'),
-        sections: z.array(
-            z.object({
-                id: z.string(),
-                name: z.string(),
-            }),
-        ),
+        sections: z.array(SectionSchema),
         children: z.array(ProjectStructureSchema).describe('Nested child projects.'),
     }),
 )


### PR DESCRIPTION
## Summary

- use the shared section output schema for sections nested under account-overview projects
- validate the sanitized structured content against the declared output schema

Closes #583
