### PR TITLE
feat: add `search-completed-tasks` tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import { projectManagement } from './tools/project-management.js'
 import { projectMove } from './tools/project-move.js'
 import { reorderObjects } from './tools/reorder-objects.js'
 import { rescheduleTasks } from './tools/reschedule-tasks.js'
+import { searchCompletedTasks } from './tools/search-completed-tasks.js'
 import { search } from './tools/search.js'
 import { uncompleteTasks } from './tools/uncomplete-tasks.js'
 import { updateComments } from './tools/update-comments.js'
@@ -78,6 +79,7 @@ export {
     findTasks,
     findTasksByDate,
     findCompletedTasks,
+    searchCompletedTasks,
     rescheduleTasks,
     // Project management tools
     addProjects,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -36,6 +36,7 @@ What each tool does and how to fill its parameters is in the tool's own descript
 **Finding things**
 
 - For "what did I complete?", call **user-info** for the asker's user ID, then **find-activity** with objectType="task", eventType="completed", initiatorId, and dateFrom/dateTo. Without initiatorId the answer covers every collaborator. find-activity reports completion events, including each occurrence of a recurring task; **find-completed-tasks** lists completed tasks, which is not the same question.
+- Use **search-completed-tasks** for completed-task text searches when the completion date is unknown. Use **find-completed-tasks** for known date windows.
 - To resolve a person's name or email to a user ID, or to answer "who is X?", use **find-project-collaborators** with just a searchTerm. It covers every shared project you can access plus yourself, so an empty result means they collaborate on none of them — not that they do not exist.
 - Before assigning work to someone, call **find-project-collaborators** again with the target projectId. Resolving an ID only proves they collaborate on *some* project you can see; assignment fails unless they collaborate on that one.
 - To find out whether a task hides subtasks, use **fetch-object** with includeChildren rather than a speculative **find-tasks** call.

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -36,6 +36,7 @@ import { projectManagement } from './tools/project-management.js'
 import { projectMove } from './tools/project-move.js'
 import { reorderObjects } from './tools/reorder-objects.js'
 import { rescheduleTasks } from './tools/reschedule-tasks.js'
+import { searchCompletedTasks } from './tools/search-completed-tasks.js'
 import { search } from './tools/search.js'
 import { uncompleteTasks } from './tools/uncomplete-tasks.js'
 import { updateComments } from './tools/update-comments.js'
@@ -84,6 +85,7 @@ const toolRegistry = {
     findTasks,
     findTasksByDate: findTasksByDateWithUi,
     findCompletedTasks,
+    searchCompletedTasks,
 
     // Project management tools
     addProjects,

--- a/src/tools/__snapshots__/find-tasks.test.ts.snap
+++ b/src/tools/__snapshots__/find-tasks.test.ts.snap
@@ -31,7 +31,7 @@ Preview:
 exports[`find-tasks tool > next steps logic > should provide helpful suggestions for empty search results 1`] = `
 "Search results for "nonexistent": 0 (limit 10).
 Filter: matching "nonexistent".
-No results. Try broader search terms; Verify spelling and try partial words; Check completed tasks with find-completed-tasks."
+No results. Try broader search terms; Verify spelling and try partial words; Search completed tasks with search-completed-tasks."
 `;
 
 exports[`find-tasks tool > next steps logic > should suggest different actions when hasOverdue is true 1`] = `
@@ -65,13 +65,13 @@ Preview:
 exports[`find-tasks tool > searching tasks > should handle search with 'empty results' 1`] = `
 "Search results for "nonexistent keyword": 0 (limit 10).
 Filter: matching "nonexistent keyword".
-No results. Try broader search terms; Verify spelling and try partial words; Check completed tasks with find-completed-tasks."
+No results. Try broader search terms; Verify spelling and try partial words; Search completed tasks with search-completed-tasks."
 `;
 
 exports[`find-tasks tool > searching tasks > should handle search with 'special characters' 1`] = `
 "Search results for "@work #urgent "exact phrase"": 0 (limit 10).
 Filter: matching "@work #urgent "exact phrase"".
-No results. Try broader search terms; Verify spelling and try partial words; Check completed tasks with find-completed-tasks."
+No results. Try broader search terms; Verify spelling and try partial words; Search completed tasks with search-completed-tasks."
 `;
 
 exports[`find-tasks tool > searching tasks > should search tasks and return results 1`] = `

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -4,7 +4,7 @@ import type { TodoistTool } from '../todoist-tool.js'
 import { mapTask, resolveInboxProjectId } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { getDateInOffset, parseGmtOffsetToMinutes, shiftDateStringByDays } from '../utils/date.js'
-import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
+import { formatLabelsHint, generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import { previewTasks, summarizeList } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -236,10 +236,7 @@ function generateTextContent({
 
     // Add label filter information
     if (args.labels && args.labels.length > 0) {
-        const labelText = args.labels
-            .map((label) => `@${label}`)
-            .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
-        filterHints.push(`labels: ${labelText}`)
+        filterHints.push(`labels: ${formatLabelsHint(args.labels, args.labelsOperator)}`)
     }
 
     // Add responsible user filter information

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -111,7 +111,7 @@ const OutputSchema = {
 const findCompletedTasks = {
     name: ToolNames.FIND_COMPLETED_TASKS,
     description:
-        'Get completed tasks in a date range. For "what did I complete/get done" questions, use find-activity instead — it reports completion events, including every occurrence of a recurring task, which this tool does not. since/until are optional and default to a 7-day window when omitted. Includes all collaborators by default. Person-specific queries (summaries, plans, reports) require responsibleUser.',
+        'Get completed tasks in a date range. Use search-completed-tasks instead for text searches when the completion date is unknown. For "what did I complete/get done" questions, use find-activity instead — it reports completion events, including every occurrence of a recurring task, which this tool does not. since/until are optional and default to a 7-day window when omitted. Includes all collaborators by default. Person-specific queries (summaries, plans, reports) require responsibleUser.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -9,7 +9,7 @@ import {
 import type { TodoistTool } from '../todoist-tool.js'
 import { getTasksByFilter } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
-import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
+import { formatLabelsHint, generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import { getDateString, previewTasks, summarizeList } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -198,10 +198,7 @@ function generateTextContent({
 
     // Add label filter information
     if (args.labels && args.labels.length > 0) {
-        const labelText = args.labels
-            .map((label) => `@${label}`)
-            .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
-        filterHints.push(`labels: ${labelText}`)
+        filterHints.push(`labels: ${formatLabelsHint(args.labels, args.labelsOperator)}`)
     }
 
     // Add responsible user filter information

--- a/src/tools/find-tasks.test.ts
+++ b/src/tools/find-tasks.test.ts
@@ -41,7 +41,7 @@ const mockResolveFilter = filterResolver.resolveFilter as MockedFunction<
     typeof filterResolver.resolveFilter
 >
 
-const { FIND_TASKS, FIND_COMPLETED_TASKS } = ToolNames
+const { FIND_TASKS, SEARCH_COMPLETED_TASKS } = ToolNames
 
 const mockGetTasksByFilter = getTasksByFilter as MockedFunction<typeof getTasksByFilter>
 const mockResolveUserNameToId = resolveUserNameToId as MockedFunction<typeof resolveUserNameToId>
@@ -433,7 +433,7 @@ describe(`${FIND_TASKS} tool`, () => {
             const textContent = result.textContent
             expect(textContent).toMatchSnapshot()
             expect(textContent).toContain('Try broader search terms')
-            expect(textContent).toContain(`Check completed tasks with ${FIND_COMPLETED_TASKS}`)
+            expect(textContent).toContain(`Search completed tasks with ${SEARCH_COMPLETED_TASKS}`)
             expect(textContent).toContain('Verify spelling and try partial words')
         })
     })

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -21,7 +21,7 @@ import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import { previewTasks, summarizeList } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
 
-const { FIND_COMPLETED_TASKS, ADD_TASKS } = ToolNames
+const { FIND_COMPLETED_TASKS, SEARCH_COMPLETED_TASKS, ADD_TASKS } = ToolNames
 
 const ArgsSchema = {
     searchText: z.string().optional().describe('The text to search for in tasks.'),
@@ -445,13 +445,17 @@ function generateTextContent({
                 const email = assigneeEmail || args.responsibleUser
                 zeroReasonHints.push(`No tasks assigned to ${email}`)
                 zeroReasonHints.push('Check if the user name is correct')
-                zeroReasonHints.push(`Check completed tasks with ${FIND_COMPLETED_TASKS}`)
+                zeroReasonHints.push(
+                    args.searchText
+                        ? `Search completed tasks with ${SEARCH_COMPLETED_TASKS}`
+                        : `Check completed tasks with ${FIND_COMPLETED_TASKS}`,
+                )
             }
             if (args.searchText) {
                 zeroReasonHints.push('Try broader search terms')
                 zeroReasonHints.push('Verify spelling and try partial words')
                 if (!args.responsibleUser) {
-                    zeroReasonHints.push(`Check completed tasks with ${FIND_COMPLETED_TASKS}`)
+                    zeroReasonHints.push(`Search completed tasks with ${SEARCH_COMPLETED_TASKS}`)
                 }
             }
         }

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -16,7 +16,7 @@ import {
 } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { filterResolver } from '../utils/filter-resolver.js'
-import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
+import { formatLabelsHint, generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import { previewTasks, summarizeList } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -377,10 +377,7 @@ function generateTextContent({
 
         // Add label filter information
         if (args.labels && args.labels.length > 0) {
-            const labelText = args.labels
-                .map((label) => `@${label}`)
-                .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
-            filterHints.push(`labels: ${labelText}`)
+            filterHints.push(`labels: ${formatLabelsHint(args.labels, args.labelsOperator)}`)
         }
 
         // Container-specific zero result hints
@@ -403,10 +400,7 @@ function generateTextContent({
             subjectParts.push(`assigned to ${email}`)
         }
         if (args.labels && args.labels.length > 0) {
-            const labelText = args.labels
-                .map((label) => `@${label}`)
-                .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
-            subjectParts.push(`with labels: ${labelText}`)
+            subjectParts.push(`with labels: ${formatLabelsHint(args.labels, args.labelsOperator)}`)
         }
 
         if (args.filter && !args.searchText && !args.responsibleUser && !args.labels?.length) {
@@ -420,10 +414,7 @@ function generateTextContent({
             subject = `Tasks assigned to ${email}`
             if (args.filter) filterHints.push(`filter: ${args.filter}`)
         } else if (args.labels && args.labels.length > 0 && !args.responsibleUser) {
-            const labelText = args.labels
-                .map((label) => `@${label}`)
-                .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
-            subject = `Tasks with labels: ${labelText}`
+            subject = `Tasks with labels: ${formatLabelsHint(args.labels, args.labelsOperator)}`
             if (args.filter) filterHints.push(`filter: ${args.filter}`)
         } else {
             subject = `Tasks ${subjectParts.join(' ')}`
@@ -434,10 +425,7 @@ function generateTextContent({
             filterHints.push(`assigned to ${email}`)
         }
         if (args.labels && args.labels.length > 0) {
-            const labelText = args.labels
-                .map((label) => `@${label}`)
-                .join(args.labelsOperator === 'and' ? ' & ' : ' | ')
-            filterHints.push(`labels: ${labelText}`)
+            filterHints.push(`labels: ${formatLabelsHint(args.labels, args.labelsOperator)}`)
         }
 
         if (tasks.length === 0) {

--- a/src/tools/search-completed-tasks.test.ts
+++ b/src/tools/search-completed-tasks.test.ts
@@ -1,0 +1,196 @@
+import type { TodoistApi } from '@doist/todoist-sdk'
+import { type Mocked, vi } from 'vitest'
+import { z } from 'zod'
+import { ApiLimits } from '../utils/constants.js'
+import { createMockTask, createMockUser, TEST_IDS } from '../utils/test-helpers.js'
+import { searchCompletedTasks } from './search-completed-tasks.js'
+
+const mockTodoistApi = {
+    searchCompletedTasks: vi.fn(),
+    getUser: vi.fn(),
+} as unknown as Mocked<TodoistApi>
+
+describe('search-completed-tasks tool', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('requires non-empty search text', () => {
+        const schema = z.object(searchCompletedTasks.parameters)
+
+        expect(schema.safeParse({}).success).toBe(false)
+        expect(schema.safeParse({ searchText: '' }).success).toBe(false)
+        expect(schema.safeParse({ searchText: 'report' }).success).toBe(true)
+    })
+
+    it('searches and maps one page of completed tasks', async () => {
+        mockTodoistApi.searchCompletedTasks.mockResolvedValue({
+            items: [
+                createMockTask({
+                    id: 'completed-task-1',
+                    content: 'Submit expense report',
+                    checked: true,
+                    completedAt: new Date('2026-08-28T18:00:00Z'),
+                }),
+            ],
+            nextCursor: null,
+        })
+
+        const result = await searchCompletedTasks.execute(
+            { searchText: 'expense report' },
+            mockTodoistApi,
+        )
+
+        expect(mockTodoistApi.searchCompletedTasks).toHaveBeenCalledWith({
+            query: 'expense report',
+            cursor: undefined,
+            limit: ApiLimits.COMPLETED_TASKS_DEFAULT,
+        })
+        expect(result.structuredContent).toMatchObject({
+            tasks: [
+                {
+                    id: 'completed-task-1',
+                    content: 'Submit expense report',
+                    checked: true,
+                    completedAt: '2026-08-28T18:00:00.000Z',
+                },
+            ],
+            totalCount: 1,
+            hasMore: false,
+            appliedFilters: {
+                searchText: 'expense report',
+                labelsOperator: 'or',
+            },
+        })
+    })
+
+    it('applies project, section, and default OR label filters to one page', async () => {
+        mockTodoistApi.searchCompletedTasks.mockResolvedValue({
+            items: [
+                createMockTask({
+                    id: 'match',
+                    projectId: 'project-1',
+                    sectionId: 'section-1',
+                    labels: ['work'],
+                }),
+                createMockTask({
+                    id: 'wrong-project',
+                    projectId: 'project-2',
+                    sectionId: 'section-1',
+                    labels: ['work'],
+                }),
+                createMockTask({
+                    id: 'wrong-section',
+                    projectId: 'project-1',
+                    sectionId: 'section-2',
+                    labels: ['work'],
+                }),
+                createMockTask({
+                    id: 'wrong-label',
+                    projectId: 'project-1',
+                    sectionId: 'section-1',
+                    labels: ['personal'],
+                }),
+            ],
+            nextCursor: 'next-page',
+        })
+
+        const result = await searchCompletedTasks.execute(
+            {
+                searchText: 'report',
+                projectId: 'project-1',
+                sectionId: 'section-1',
+                labels: ['work', 'urgent'],
+                cursor: 'current-page',
+            },
+            mockTodoistApi,
+        )
+
+        expect(mockTodoistApi.searchCompletedTasks).toHaveBeenCalledWith({
+            query: 'report',
+            cursor: 'current-page',
+            limit: ApiLimits.COMPLETED_TASKS_DEFAULT,
+        })
+        expect(mockTodoistApi.getUser).not.toHaveBeenCalled()
+        expect(result.structuredContent).toMatchObject({
+            tasks: [{ id: 'match' }],
+            nextCursor: 'next-page',
+            totalCount: 1,
+            hasMore: true,
+        })
+        expect(result.textContent).toContain('client-side')
+        expect(result.textContent).toContain('project: project-1')
+        expect(result.textContent).toContain('section: section-1')
+        expect(result.textContent).toContain('labels: @work | @urgent')
+        expect(result.textContent).toContain("Pass cursor 'next-page' to fetch more results.")
+    })
+
+    it('requires every requested label with the AND operator', async () => {
+        mockTodoistApi.searchCompletedTasks.mockResolvedValue({
+            items: [
+                createMockTask({ id: 'one-label', labels: ['work'] }),
+                createMockTask({ id: 'both-labels', labels: ['work', 'urgent'] }),
+            ],
+            nextCursor: null,
+        })
+
+        const result = await searchCompletedTasks.execute(
+            {
+                searchText: 'report',
+                labels: ['work', 'urgent'],
+                labelsOperator: 'and',
+            },
+            mockTodoistApi,
+        )
+
+        expect(result.structuredContent.tasks.map((task) => task.id)).toEqual(['both-labels'])
+        expect(result.structuredContent.appliedFilters).toEqual({
+            searchText: 'report',
+            labels: ['work', 'urgent'],
+            labelsOperator: 'and',
+        })
+    })
+
+    it('resolves the inbox project only when requested', async () => {
+        mockTodoistApi.getUser.mockResolvedValue(
+            createMockUser({ inboxProjectId: TEST_IDS.PROJECT_INBOX }),
+        )
+        mockTodoistApi.searchCompletedTasks.mockResolvedValue({
+            items: [
+                createMockTask({ id: 'inbox-task', projectId: TEST_IDS.PROJECT_INBOX }),
+                createMockTask({ id: 'other-task', projectId: TEST_IDS.PROJECT_WORK }),
+            ],
+            nextCursor: null,
+        })
+
+        const result = await searchCompletedTasks.execute(
+            { searchText: 'task', projectId: 'inbox' },
+            mockTodoistApi,
+        )
+
+        expect(mockTodoistApi.getUser).toHaveBeenCalledTimes(1)
+        expect(result.structuredContent.tasks.map((task) => task.id)).toEqual(['inbox-task'])
+        expect(result.structuredContent.appliedFilters).toMatchObject({ projectId: 'inbox' })
+    })
+
+    it('keeps pagination when client-side filters remove every task', async () => {
+        mockTodoistApi.searchCompletedTasks.mockResolvedValue({
+            items: [createMockTask({ projectId: 'other-project' })],
+            nextCursor: 'later-page',
+        })
+
+        const result = await searchCompletedTasks.execute(
+            { searchText: 'report', projectId: 'wanted-project' },
+            mockTodoistApi,
+        )
+
+        expect(result.structuredContent).toMatchObject({
+            tasks: [],
+            nextCursor: 'later-page',
+            totalCount: 0,
+            hasMore: true,
+        })
+        expect(result.textContent).toContain('client-side')
+        expect(result.textContent).toContain("Pass cursor 'later-page' to fetch more results.")
+    })
+})

--- a/src/tools/search-completed-tasks.ts
+++ b/src/tools/search-completed-tasks.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod'
+import type { TodoistTool } from '../todoist-tool.js'
+import { mapTask, resolveInboxProjectId } from '../tool-helpers.js'
+import { ApiLimits } from '../utils/constants.js'
+import { formatLabelsHint, LabelsSchema } from '../utils/labels.js'
+import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
+import { previewTasks, summarizeList } from '../utils/response-builders.js'
+import { ToolNames } from '../utils/tool-names.js'
+
+const ArgsSchema = {
+    searchText: z
+        .string()
+        .min(1)
+        .describe('The text to search for in completed task titles and descriptions.'),
+    projectId: z
+        .string()
+        .optional()
+        .describe(
+            'Find completed tasks in this project. Project ID should be an ID string, or the text "inbox", for inbox tasks.',
+        ),
+    sectionId: z.string().optional().describe('Find completed tasks in this section.'),
+    ...LabelsSchema,
+    cursor: z
+        .string()
+        .optional()
+        .describe('The cursor from the previous call, with the same search and filters.'),
+}
+
+const OutputSchema = {
+    tasks: z.array(TaskOutputSchema).describe('The found completed tasks.'),
+    nextCursor: z.string().optional(),
+    totalCount: z.number().describe('The total number of tasks in this page.'),
+    hasMore: z.boolean(),
+    appliedFilters: z.record(z.string(), z.unknown()),
+}
+
+const searchCompletedTasks = {
+    name: ToolNames.SEARCH_COMPLETED_TASKS,
+    description:
+        'Search completed tasks when the completion date is unknown. All search words must match the task title or description; comments are not searched. Results are ordered by completion time, newest first. Returns up to 50 tasks per page, or fewer after client-side project, section, and label filters. Tasks in archived projects are not returned. Use find-completed-tasks for completion-date windows.',
+    parameters: ArgsSchema,
+    outputSchema: OutputSchema,
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+    async execute(args, client) {
+        const { searchText, projectId, sectionId, labels, labelsOperator = 'or', cursor } = args
+        const resolvedProjectId = await resolveInboxProjectId({ projectId, client })
+        const { items, nextCursor } = await client.searchCompletedTasks({
+            query: searchText,
+            cursor,
+            limit: ApiLimits.COMPLETED_TASKS_DEFAULT,
+        })
+        const tasks = items
+            .map(mapTask)
+            .filter((task) => !resolvedProjectId || task.projectId === resolvedProjectId)
+            .filter((task) => !sectionId || task.sectionId === sectionId)
+            .filter((task) => {
+                if (!labels?.length) return true
+                return labelsOperator === 'and'
+                    ? labels.every((label) => task.labels.includes(label))
+                    : labels.some((label) => task.labels.includes(label))
+            })
+        const hasClientSideFilters = Boolean(projectId || sectionId || labels?.length)
+        const appliedFilters = { ...args, labelsOperator }
+        const filterHints = [`text: ${searchText}`]
+        if (projectId) filterHints.push(`project: ${projectId}`)
+        if (sectionId) filterHints.push(`section: ${sectionId}`)
+        if (labels?.length) {
+            filterHints.push(`labels: ${formatLabelsHint(labels, labelsOperator)}`)
+        }
+
+        return {
+            textContent: summarizeList({
+                subject: 'Completed task search results',
+                count: tasks.length,
+                nextCursor: nextCursor ?? undefined,
+                filterHints,
+                previewLines: previewTasks(tasks),
+                zeroReasonHints: ['Try broader search terms'],
+                nextSteps: hasClientSideFilters
+                    ? ['Project, section, and label filters are client-side and apply per page.']
+                    : undefined,
+            }),
+            structuredContent: {
+                tasks,
+                nextCursor: nextCursor ?? undefined,
+                totalCount: tasks.length,
+                hasMore: Boolean(nextCursor),
+                appliedFilters,
+            },
+        }
+    },
+} satisfies TodoistTool<typeof ArgsSchema, typeof OutputSchema>
+
+export { searchCompletedTasks }

--- a/src/tools/tool-annotations.test.ts
+++ b/src/tools/tool-annotations.test.ts
@@ -74,6 +74,13 @@ const TOOL_EXPECTATIONS: ToolExpectation[] = [
         idempotentHint: true,
     },
     {
+        name: ToolNames.SEARCH_COMPLETED_TASKS,
+        title: 'Todoist: Search Completed Tasks',
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+    },
+    {
         name: ToolNames.ADD_PROJECTS,
         title: 'Todoist: Add Projects',
         readOnlyHint: false,

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -13,6 +13,13 @@ export const LabelsSchema = {
         ),
 }
 
+/**
+ * Formats labels for human-readable filter hints, e.g. "@work & @urgent".
+ */
+export function formatLabelsHint(labels: string[], labelsOperator: LabelsOperator = 'or') {
+    return labels.map((label) => `@${label}`).join(labelsOperator === 'and' ? ' & ' : ' | ')
+}
+
 export function generateLabelsFilter(labels: string[] = [], labelsOperator: LabelsOperator = 'or') {
     if (labels.length === 0) return ''
     const operator = labelsOperator === 'and' ? ' & ' : ' | '

--- a/src/utils/tool-names.ts
+++ b/src/utils/tool-names.ts
@@ -14,6 +14,7 @@ export const ToolNames = {
     FIND_TASKS: 'find-tasks',
     FIND_TASKS_BY_DATE: 'find-tasks-by-date',
     FIND_COMPLETED_TASKS: 'find-completed-tasks',
+    SEARCH_COMPLETED_TASKS: 'search-completed-tasks',
     RESCHEDULE_TASKS: 'reschedule-tasks',
 
     // Project management tools


### PR DESCRIPTION
Part of #574

## Short description

We are adding a new `search-completed-tasks` tool to allow for text search across completed tasks. It supports client-side filtering for project, section, and label (as in `find-tasks`).

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (README, etc.)
- [x] New tools added to getMcpServer AND exported in src/index.ts.