### PR TITLE
feat(search): Add support for completed tasks

### DIFF
--- a/src/tools/search.test.ts
+++ b/src/tools/search.test.ts
@@ -1,10 +1,12 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
 import { type Mocked, type MockedFunction, vi } from 'vitest'
 import { getTasksByFilter } from '../tool-helpers.js'
+import { ApiLimits } from '../utils/constants.js'
 import {
     createMappedTask,
     createMockApiResponse,
     createMockProject,
+    createMockTask,
     TEST_IDS,
 } from '../utils/test-helpers.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -25,11 +27,13 @@ const mockGetTasksByFilter = getTasksByFilter as MockedFunction<typeof getTasksB
 // Mock the Todoist API
 const mockTodoistApi = {
     searchProjects: vi.fn(),
+    searchCompletedTasks: vi.fn(),
 } as unknown as Mocked<TodoistApi>
 
 describe(`${SEARCH} tool`, () => {
     beforeEach(() => {
         vi.clearAllMocks()
+        mockTodoistApi.searchCompletedTasks.mockResolvedValue({ items: [], nextCursor: null })
     })
 
     describe('searching tasks and projects', () => {
@@ -91,6 +95,51 @@ describe(`${SEARCH} tool`, () => {
                 id: `project:${TEST_IDS.PROJECT_WORK}`,
                 title: 'Important Work Project',
                 url: `https://app.todoist.com/app/project/${TEST_IDS.PROJECT_WORK}`,
+            })
+        })
+
+        it('lists completed tasks after active tasks and before projects', async () => {
+            mockGetTasksByFilter.mockResolvedValue({
+                tasks: [createMappedTask({ id: 'active-task', content: 'Active report' })],
+                nextCursor: null,
+            })
+            mockTodoistApi.searchCompletedTasks.mockResolvedValue({
+                items: [createMockTask({ id: 'completed-task', content: 'Completed report' })],
+                nextCursor: 'ignored-next-page',
+            })
+            mockTodoistApi.searchProjects.mockResolvedValue(
+                createMockApiResponse([
+                    createMockProject({ id: 'report-project', name: 'Report project' }),
+                ]),
+            )
+
+            const result = await search.execute({ query: 'report' }, mockTodoistApi)
+
+            expect(mockTodoistApi.searchCompletedTasks).toHaveBeenCalledWith({
+                query: 'report',
+                limit: ApiLimits.COMPLETED_TASKS_DEFAULT,
+            })
+            const expectedResults = [
+                {
+                    id: 'task:active-task',
+                    title: 'Active report',
+                    url: 'https://app.todoist.com/app/task/active-task',
+                },
+                {
+                    id: 'task:completed-task',
+                    title: '[completed] Completed report',
+                    url: 'https://app.todoist.com/app/task/completed-task',
+                },
+                {
+                    id: 'project:report-project',
+                    title: 'Report project',
+                    url: 'https://app.todoist.com/app/project/report-project',
+                },
+            ]
+            expect(JSON.parse(result.textContent ?? '{}').results).toEqual(expectedResults)
+            expect(result.structuredContent).toEqual({
+                results: expectedResults,
+                totalCount: 3,
             })
         })
 
@@ -195,6 +244,18 @@ describe(`${SEARCH} tool`, () => {
 
             await expect(search.execute({ query: 'test' }, mockTodoistApi)).rejects.toThrow(
                 'Project search failed',
+            )
+        })
+
+        it('should throw error for completed task search failure', async () => {
+            mockGetTasksByFilter.mockResolvedValue({ tasks: [], nextCursor: null })
+            mockTodoistApi.searchCompletedTasks.mockRejectedValue(
+                new Error('Completed task search failed'),
+            )
+            mockTodoistApi.searchProjects.mockResolvedValue(createMockApiResponse([]))
+
+            await expect(search.execute({ query: 'test' }, mockTodoistApi)).rejects.toThrow(
+                'Completed task search failed',
             )
         })
     })

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -59,35 +59,24 @@ const search = {
             searchAllProjects(client, query),
         ])
 
-        // Build results array
-        const results: SearchResult[] = []
-
-        // Add task results with composite IDs
-        for (const task of tasksResult.tasks) {
-            results.push({
+        // Build results with composite IDs: active tasks, then completed tasks, then projects
+        const results: SearchResult[] = [
+            ...tasksResult.tasks.map((task) => ({
                 id: `task:${task.id}`,
                 title: task.content,
                 url: getTaskUrl(task.id),
-            })
-        }
-
-        // Add completed task results after active tasks
-        for (const task of completedTasksResult.items) {
-            results.push({
+            })),
+            ...completedTasksResult.items.map((task) => ({
                 id: `task:${task.id}`,
                 title: `[completed] ${task.content}`,
                 url: getTaskUrl(task.id),
-            })
-        }
-
-        // Add project results with composite IDs
-        for (const project of projects) {
-            results.push({
+            })),
+            ...projects.map((project) => ({
                 id: `project:${project.id}`,
                 title: project.name,
                 url: getProjectUrl(project.id),
-            })
-        }
+            })),
+        ]
 
         return {
             textContent: JSON.stringify({ results }),

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -37,23 +37,25 @@ const OutputSchema = {
 const search = {
     name: ToolNames.SEARCH,
     description:
-        'Search across tasks and projects in Todoist. Returns a list of relevant results with IDs, titles, and URLs.',
+        'Search across active tasks, completed tasks, and projects in Todoist. Returns a list of relevant results with IDs, titles, and URLs. Completed task titles start with "[completed]".',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
         const { query } = args
 
-        // Search both tasks and projects in parallel
+        // Search active tasks, completed tasks, and projects in parallel
         // Use TASKS_MAX for search since this tool doesn't support pagination
+        // Completed task search returns at most one 50-item page
         // For projects, use server-side search
-        const [tasksResult, projects] = await Promise.all([
+        const [tasksResult, completedTasksResult, projects] = await Promise.all([
             getTasksByFilter({
                 client,
                 query: `search: ${query}`,
                 limit: ApiLimits.TASKS_MAX,
                 cursor: undefined,
             }),
+            client.searchCompletedTasks({ query, limit: ApiLimits.COMPLETED_TASKS_DEFAULT }),
             searchAllProjects(client, query),
         ])
 
@@ -65,6 +67,15 @@ const search = {
             results.push({
                 id: `task:${task.id}`,
                 title: task.content,
+                url: getTaskUrl(task.id),
+            })
+        }
+
+        // Add completed task results after active tasks
+        for (const task of completedTasksResult.items) {
+            results.push({
+                id: `task:${task.id}`,
+                title: `[completed] ${task.content}`,
                 url: getTaskUrl(task.id),
             })
         }


### PR DESCRIPTION
Closes #574

## Short description

We are adding the `search-completed-tasks` tool to the `search` tool. It adds completed tasks to the results, whose titles are prefixed with `[completed]`. The completed tasks are listed after active tasks, but before projects.

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (README, etc.)
- [x] New tools added to getMcpServer AND exported in src/index.ts.
