### PR TITLE
fix: preserve day units in task duration output (Doist/Issues#21004)

### DIFF
--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -78,7 +78,7 @@ describe('shared utilities', () => {
             expect(result.duration).toBe(undefined)
         })
 
-        it('should handle task with duration', () => {
+        it('should format minute durations', () => {
             const mockTask = createMockTask({
                 id: '789',
                 content: 'Task with duration',
@@ -88,6 +88,18 @@ describe('shared utilities', () => {
 
             const result = mapTask(mockTask)
             expect(result.duration).toBe('2h30m')
+        })
+
+        it('should format day durations', () => {
+            const mockTask = createMockTask({
+                id: '789',
+                content: 'Task with duration',
+                projectId: 'proj-1',
+                duration: { amount: 4, unit: 'day' },
+            })
+
+            const result = mapTask(mockTask)
+            expect(result.duration).toBe('4d')
         })
 
         it('should preserve markdown links and formatting in content and description', () => {

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -330,7 +330,11 @@ function mapTask(task: Task) {
         sectionId: task.sectionId ?? undefined,
         parentId: task.parentId ?? undefined,
         labels: task.labels,
-        duration: task.duration ? formatDuration(task.duration.amount) : undefined,
+        duration: task.duration
+            ? task.duration.unit === 'day'
+                ? `${task.duration.amount}d`
+                : formatDuration(task.duration.amount)
+            : undefined,
         responsibleUid: task.responsibleUid ?? undefined,
         assignedByUid: task.assignedByUid ?? undefined,
         checked: task.checked,

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -20,7 +20,7 @@ const TaskSchema = z.object({
     sectionId: z.string().optional(),
     parentId: z.string().optional(),
     labels: z.array(z.string()).optional(),
-    duration: z.string().optional().describe('e.g. "2h30m".'),
+    duration: z.string().optional().describe('e.g. "2h30m" or "4d".'),
     responsibleUid: z.string().optional(),
     isUncompletable: z.boolean().optional().describe('An organizational header, not a real task.'),
     assignedByUid: z.string().optional(),


### PR DESCRIPTION
# Pull Request

Closes https://github.com/Doist/Issues/issues/21004

## Short description

Task mapping now preserves duration units: minute durations retain hour/minute formatting, and day durations are returned with a `d` suffix. Added regression coverage and documented the day-duration output format.

## PR Checklist

- [x] Added tests for bugs / new features
- [x] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.