### PR TITLE
fix: include unassigned tasks for current-user queries (Doist/Issues#21012)

### DIFF
--- a/src/filter-helpers.test.ts
+++ b/src/filter-helpers.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildResponsibleUserQueryFilter, filterTasksByResponsibleUser } from './filter-helpers.js'
+
+describe('filter helpers', () => {
+    describe('buildResponsibleUserQueryFilter', () => {
+        it('includes unassigned tasks when the resolved user is the current user', () => {
+            expect(
+                buildResponsibleUserQueryFilter({
+                    resolvedAssigneeId: 'current-user',
+                    assigneeEmail: 'avery.inboxworthy@example.com',
+                    currentUserId: 'current-user',
+                }),
+            ).toBe('!assigned to: others')
+        })
+
+        it('keeps a resolved user filter strict when the current user is unavailable', () => {
+            expect(
+                buildResponsibleUserQueryFilter({
+                    resolvedAssigneeId: 'current-user',
+                    assigneeEmail: 'avery.inboxworthy@example.com',
+                }),
+            ).toBe('assigned to: avery.inboxworthy@example.com')
+        })
+    })
+
+    describe('filterTasksByResponsibleUser', () => {
+        it('includes unassigned tasks when the resolved user is the current user', () => {
+            const tasks = [
+                { id: 'mine', responsibleUid: 'current-user' },
+                { id: 'unassigned' },
+                { id: 'someone-else', responsibleUid: 'other-user' },
+            ]
+
+            expect(
+                filterTasksByResponsibleUser({
+                    tasks,
+                    resolvedAssigneeId: 'current-user',
+                    currentUserId: 'current-user',
+                }),
+            ).toEqual([tasks[0], tasks[1]])
+        })
+    })
+})

--- a/src/filter-helpers.test.ts
+++ b/src/filter-helpers.test.ts
@@ -9,6 +9,7 @@ describe('filter helpers', () => {
                     resolvedAssigneeId: 'current-user',
                     assigneeEmail: 'avery.inboxworthy@example.com',
                     currentUserId: 'current-user',
+                    responsibleUserFiltering: 'all',
                 }),
             ).toBe('!assigned to: others')
         })
@@ -36,6 +37,7 @@ describe('filter helpers', () => {
                     tasks,
                     resolvedAssigneeId: 'current-user',
                     currentUserId: 'current-user',
+                    responsibleUserFiltering: 'all',
                 }),
             ).toEqual([tasks[0], tasks[1]])
         })

--- a/src/filter-helpers.ts
+++ b/src/filter-helpers.ts
@@ -64,16 +64,14 @@ export function buildResponsibleUserQueryFilter({
     currentUserId?: string
     responsibleUserFiltering?: ResponsibleUserFiltering
 }): string {
-    if (resolvedAssigneeId && assigneeEmail) {
-        if (resolvedAssigneeId !== currentUserId) {
-            return `assigned to: ${assigneeEmail}`
-        }
-        return '!assigned to: others'
+    const isCurrentUser =
+        Boolean(resolvedAssigneeId && assigneeEmail) && resolvedAssigneeId === currentUserId
+
+    if (resolvedAssigneeId && assigneeEmail && !isCurrentUser) {
+        return `assigned to: ${assigneeEmail}`
     }
 
-    // Otherwise use the filtering mode
-    if (responsibleUserFiltering === 'unassignedOrMe') {
-        // Exclude tasks assigned to others (keeps unassigned + assigned to me)
+    if (isCurrentUser || responsibleUserFiltering === 'unassignedOrMe') {
         return '!assigned to: others'
     }
 
@@ -106,16 +104,19 @@ export function filterTasksByResponsibleUser<T extends { responsibleUid?: string
     currentUserId: string
     responsibleUserFiltering?: ResponsibleUserFiltering
 }): T[] {
-    if (resolvedAssigneeId) {
-        if (resolvedAssigneeId !== currentUserId) {
-            return tasks.filter((task) => task.responsibleUid === resolvedAssigneeId)
-        }
-        return tasks.filter((task) => !task.responsibleUid || task.responsibleUid === currentUserId)
-    } else if (responsibleUserFiltering === 'unassignedOrMe') {
-        return tasks.filter((task) => !task.responsibleUid || task.responsibleUid === currentUserId)
-    } else if (responsibleUserFiltering === 'assigned') {
-        return tasks.filter((task) => task.responsibleUid && task.responsibleUid !== currentUserId)
-    } else {
-        return tasks
+    const isCurrentUser = Boolean(resolvedAssigneeId) && resolvedAssigneeId === currentUserId
+
+    if (resolvedAssigneeId && !isCurrentUser) {
+        return tasks.filter((task) => task.responsibleUid === resolvedAssigneeId)
     }
+
+    if (isCurrentUser || responsibleUserFiltering === 'unassignedOrMe') {
+        return tasks.filter((task) => !task.responsibleUid || task.responsibleUid === currentUserId)
+    }
+
+    if (responsibleUserFiltering === 'assigned') {
+        return tasks.filter((task) => task.responsibleUid && task.responsibleUid !== currentUserId)
+    }
+
+    return tasks
 }

--- a/src/filter-helpers.ts
+++ b/src/filter-helpers.ts
@@ -49,21 +49,26 @@ export function appendToQuery(query: string, filterComponent: string): string {
  * Builds a query filter string for responsible user filtering that can be appended to a Todoist filter query.
  * @param resolvedAssigneeId - The resolved assignee ID (if provided)
  * @param assigneeEmail - The assignee email (if provided)
+ * @param currentUserId - The current authenticated user's ID
  * @param responsibleUserFiltering - The filtering mode ('assigned', 'unassignedOrMe', 'all')
  * @returns Query filter string (e.g., "assigned to: email@example.com" or "!assigned to: others")
  */
 export function buildResponsibleUserQueryFilter({
     resolvedAssigneeId,
     assigneeEmail,
+    currentUserId,
     responsibleUserFiltering = 'unassignedOrMe',
 }: {
     resolvedAssigneeId: string | undefined
     assigneeEmail: string | undefined
+    currentUserId?: string
     responsibleUserFiltering?: ResponsibleUserFiltering
 }): string {
     if (resolvedAssigneeId && assigneeEmail) {
-        // If specific user is provided, filter by that user
-        return `assigned to: ${assigneeEmail}`
+        if (resolvedAssigneeId !== currentUserId) {
+            return `assigned to: ${assigneeEmail}`
+        }
+        return '!assigned to: others'
     }
 
     // Otherwise use the filtering mode
@@ -83,8 +88,8 @@ export function buildResponsibleUserQueryFilter({
 
 /**
  * Filters tasks based on responsible user logic:
- * - If resolvedAssigneeId is provided: returns only tasks assigned to that user
- * - If no resolvedAssigneeId: returns only unassigned tasks or tasks assigned to current user
+ * - If resolvedAssigneeId is another user: returns only tasks assigned to that user
+ * - Otherwise: returns only unassigned tasks or tasks assigned to current user
  * @param tasks - Array of tasks to filter (must have responsibleUid property)
  * @param resolvedAssigneeId - The resolved assignee ID to filter by (optional)
  * @param currentUserId - The current authenticated user's ID
@@ -102,8 +107,10 @@ export function filterTasksByResponsibleUser<T extends { responsibleUid?: string
     responsibleUserFiltering?: ResponsibleUserFiltering
 }): T[] {
     if (resolvedAssigneeId) {
-        // If responsibleUser provided, only return tasks assigned to that user
-        return tasks.filter((task) => task.responsibleUid === resolvedAssigneeId)
+        if (resolvedAssigneeId !== currentUserId) {
+            return tasks.filter((task) => task.responsibleUid === resolvedAssigneeId)
+        }
+        return tasks.filter((task) => !task.responsibleUid || task.responsibleUid === currentUserId)
     } else if (responsibleUserFiltering === 'unassignedOrMe') {
         return tasks.filter((task) => !task.responsibleUid || task.responsibleUid === currentUserId)
     } else if (responsibleUserFiltering === 'assigned') {

--- a/src/tools/find-tasks-by-date-timezone.test.ts
+++ b/src/tools/find-tasks-by-date-timezone.test.ts
@@ -15,6 +15,7 @@ vi.mock('../tool-helpers', async () => {
 
 vi.mock('../utils/user-resolver', () => ({
     resolveUserNameToId: vi.fn(),
+    SELF_USER_KEYWORD: 'me',
 }))
 
 const mockGetTasksByFilter = getTasksByFilter as MockedFunction<typeof getTasksByFilter>

--- a/src/tools/find-tasks-by-date.test.ts
+++ b/src/tools/find-tasks-by-date.test.ts
@@ -18,6 +18,7 @@ vi.mock('../tool-helpers', async () => {
 // Mock user resolver
 vi.mock('../utils/user-resolver', () => ({
     resolveUserNameToId: vi.fn(),
+    SELF_USER_KEYWORD: 'me',
 }))
 
 const mockGetTasksByFilter = getTasksByFilter as MockedFunction<typeof getTasksByFilter>
@@ -599,6 +600,7 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
             )
 
             expect(mockResolveUserNameToId).toHaveBeenCalledWith(mockTodoistApi, 'john@example.com')
+            expect(mockTodoistApi.getUser).toHaveBeenCalledTimes(1)
 
             expect(mockGetTasksByFilter).toHaveBeenCalledWith({
                 client: mockTodoistApi,
@@ -632,6 +634,7 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
             )
 
             expect(mockResolveUserNameToId).toHaveBeenCalledWith(mockTodoistApi, 'me')
+            expect(mockTodoistApi.getUser).not.toHaveBeenCalled()
 
             expect(mockGetTasksByFilter).toHaveBeenCalledWith({
                 client: mockTodoistApi,

--- a/src/tools/find-tasks-by-date.test.ts
+++ b/src/tools/find-tasks-by-date.test.ts
@@ -612,6 +612,35 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
             expect(textContent).toMatchSnapshot()
         })
 
+        it('should include unassigned tasks when responsibleUser resolves to current user', async () => {
+            mockResolveUserNameToId.mockResolvedValue({
+                userId: TEST_IDS.USER_ID,
+                displayName: 'Avery Inboxworthy',
+                email: 'avery.inboxworthy@example.com',
+            })
+
+            mockGetTasksByFilter.mockResolvedValue({ tasks: [], nextCursor: null })
+
+            await findTasksByDate.execute(
+                {
+                    startDate: 'today',
+                    daysCount: 1,
+                    limit: 50,
+                    responsibleUser: 'me',
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockResolveUserNameToId).toHaveBeenCalledWith(mockTodoistApi, 'me')
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '(today | overdue) & !assigned to: others',
+                cursor: undefined,
+                limit: 50,
+            })
+        })
+
         it('should throw error when user cannot be resolved', async () => {
             mockResolveUserNameToId.mockResolvedValue(null)
 

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -13,6 +13,7 @@ import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
 import { getDateString, previewTasks, summarizeList } from '../utils/response-builders.js'
 import { ToolNames } from '../utils/tool-names.js'
+import { SELF_USER_KEYWORD } from '../utils/user-resolver.js'
 
 /**
  * Parse a YYYY-MM-DD string as local midnight (not UTC)
@@ -98,7 +99,12 @@ const findTasksByDate = {
         const resolved = await resolveResponsibleUser(client, args.responsibleUser)
         const resolvedAssigneeId = resolved?.userId
         const assigneeEmail = resolved?.email
-        const currentUserId = resolvedAssigneeId ? (await client.getUser()).id : undefined
+        const isCurrentUserQuery = args.responsibleUser?.trim().toLowerCase() === SELF_USER_KEYWORD
+        const currentUserId = isCurrentUserQuery
+            ? resolvedAssigneeId
+            : resolvedAssigneeId
+              ? (await client.getUser()).id
+              : undefined
 
         let query = ''
 

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -61,7 +61,7 @@ export const ArgsSchema = {
         .string()
         .optional()
         .describe(
-            'Filter tasks assigned to this user. User ID, name, or email. For personal queries (summaries, plans, reports), set to current user from user-info to exclude collaborators.',
+            'Filter tasks assigned to this user. User ID, name, or email. The current user also includes unassigned tasks.',
         ),
     responsibleUserFiltering: z
         .enum(RESPONSIBLE_USER_FILTERING)
@@ -83,7 +83,7 @@ const OutputSchema = {
 const findTasksByDate = {
     name: ToolNames.FIND_TASKS_BY_DATE,
     description:
-        "Get tasks by date range. startDate='today' includes overdue items. Default responsibleUserFiltering='unassignedOrMe' excludes others' tasks. Person-specific queries (summaries, plans, reports) require responsibleUser.",
+        "Get tasks by date range. startDate='today' includes overdue items. Default responsibleUserFiltering='unassignedOrMe' excludes others' tasks.",
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
@@ -98,6 +98,7 @@ const findTasksByDate = {
         const resolved = await resolveResponsibleUser(client, args.responsibleUser)
         const resolvedAssigneeId = resolved?.userId
         const assigneeEmail = resolved?.email
+        const currentUserId = resolvedAssigneeId ? (await client.getUser()).id : undefined
 
         let query = ''
 
@@ -138,6 +139,7 @@ const findTasksByDate = {
         const responsibleUserFilter = buildResponsibleUserQueryFilter({
             resolvedAssigneeId,
             assigneeEmail,
+            currentUserId,
             responsibleUserFiltering: args.responsibleUserFiltering,
         })
         query = appendToQuery(query, responsibleUserFilter)

--- a/src/tools/find-tasks.test.ts
+++ b/src/tools/find-tasks.test.ts
@@ -1011,6 +1011,43 @@ End of test content.`
                 expect(structuredContent.tasks).toHaveLength(1)
                 expect((structuredContent.tasks as MappedTask[])[0]?.id).toBe(TEST_IDS.TASK_1)
             })
+
+            it('should include unassigned tasks for current user in container results', async () => {
+                const mockTasks = [
+                    createMockTask({
+                        id: TEST_IDS.TASK_1,
+                        responsibleUid: TEST_IDS.USER_ID,
+                    }),
+                    createMockTask({
+                        id: TEST_IDS.TASK_2,
+                        responsibleUid: null,
+                    }),
+                    createMockTask({
+                        id: TEST_IDS.TASK_3,
+                        responsibleUid: 'other-user-id',
+                    }),
+                ]
+
+                mockTodoistApi.getTasks.mockResolvedValue(createMockApiResponse(mockTasks))
+
+                mockResolveUserNameToId.mockResolvedValue({
+                    userId: TEST_IDS.USER_ID,
+                    displayName: 'Avery Inboxworthy',
+                    email: 'avery.inboxworthy@example.com',
+                })
+
+                const result = await findTasks.execute(
+                    { projectId: TEST_IDS.PROJECT_WORK, responsibleUser: 'me', limit: 10 },
+                    mockTodoistApi,
+                )
+
+                const structuredContent = result.structuredContent
+
+                expect((structuredContent.tasks as MappedTask[]).map((task) => task.id)).toEqual([
+                    TEST_IDS.TASK_1,
+                    TEST_IDS.TASK_2,
+                ])
+            })
         })
     })
 
@@ -1089,6 +1126,30 @@ End of test content.`
             expect(mockGetTasksByFilter).toHaveBeenCalledWith({
                 client: mockTodoistApi,
                 query: '(##Work) & assigned to: jane@example.com',
+                cursor: undefined,
+                limit: 10,
+            })
+        })
+
+        it('should include unassigned tasks when responsibleUser resolves to current user', async () => {
+            mockResolveUserNameToId.mockResolvedValue({
+                userId: TEST_IDS.USER_ID,
+                displayName: 'Avery Inboxworthy',
+                email: 'avery.inboxworthy@example.com',
+            })
+
+            mockGetTasksByFilter.mockResolvedValue({ tasks: [], nextCursor: null })
+
+            await findTasks.execute(
+                { filter: 'today | overdue', responsibleUser: 'me', limit: 10 },
+                mockTodoistApi,
+            )
+
+            expect(mockResolveUserNameToId).toHaveBeenCalledWith(mockTodoistApi, 'me')
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith({
+                client: mockTodoistApi,
+                query: '(today | overdue) & !assigned to: others',
                 cursor: undefined,
                 limit: 10,
             })

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -36,7 +36,9 @@ const ArgsSchema = {
     responsibleUser: z
         .string()
         .optional()
-        .describe('Find tasks assigned to this user. Can be a user ID, name, or email address.'),
+        .describe(
+            'Find tasks assigned to this user. Can be a user ID, name, or email address. The current user also includes unassigned tasks.',
+        ),
     responsibleUserFiltering: z
         .enum(RESPONSIBLE_USER_FILTERING)
         .optional()
@@ -212,10 +214,16 @@ const findTasks = {
             }
         }
 
-        // If only responsibleUid is provided (without containers or raw filter), use assignee filter
+        // If only responsibleUid is provided (without containers or raw filter), use responsible user filtering
         if (resolvedAssigneeId && !searchText && !hasLabels && !resolvedFilter) {
+            const responsibleUserFilter = buildResponsibleUserQueryFilter({
+                resolvedAssigneeId,
+                assigneeEmail,
+                currentUserId: todoistUser.id,
+                responsibleUserFiltering,
+            })
             const { results: tasks, nextCursor } = await client.getTasksByFilter({
-                query: `assigned to: ${assigneeEmail}`,
+                query: responsibleUserFilter,
                 lang: 'en',
                 limit,
                 cursor: cursor ?? null,
@@ -265,6 +273,7 @@ const findTasks = {
             const responsibleUserFilter = buildResponsibleUserQueryFilter({
                 resolvedAssigneeId,
                 assigneeEmail,
+                currentUserId: todoistUser.id,
                 responsibleUserFiltering,
             })
             query = appendToQuery(query, responsibleUserFilter)


### PR DESCRIPTION
# Pull Request

Closes https://github.com/Doist/Issues/issues/21012

## Short description

Current-user `responsibleUser` queries now include both unassigned tasks and tasks assigned to the authenticated user. Queries for other collaborators remain strictly assignee-scoped. Updated MCP descriptions direct personal date queries toward the default `unassignedOrMe` scope.

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

- [x] Added tests for bugs / new features
- [x] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.