### PR TITLE
fix: normalize first-page task cursors

### DIFF
--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -7,6 +7,7 @@ import {
     mapProject,
     mapTask,
     matchesWildcardQuery,
+    normalizePaginationCursor,
     searchAllProjects,
     searchAllSections,
     toWildcardQuery,
@@ -20,6 +21,22 @@ import {
 } from './utils/test-helpers.js'
 
 describe('shared utilities', () => {
+    describe('normalizePaginationCursor', () => {
+        it.each([undefined, '', '   ', '0', ' 0 '])(
+            'should omit first-page cursor sentinel %j',
+            (cursor) => {
+                expect(normalizePaginationCursor(cursor)).toBeUndefined()
+            },
+        )
+
+        it.each(['opaque-cursor', ' opaque-cursor '])(
+            'should preserve valid opaque cursor %j exactly',
+            (cursor) => {
+                expect(normalizePaginationCursor(cursor)).toBe(cursor)
+            },
+        )
+    })
+
     describe('mapTask', () => {
         it('should map a basic task correctly', () => {
             const mockTask = createMockTask({

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -425,6 +425,14 @@ const ErrorSchema = z.object({
     }),
 })
 
+/**
+ * Normalize first-page cursor values commonly emitted by schema-driven clients.
+ */
+export function normalizePaginationCursor(cursor: string | undefined): string | undefined {
+    const normalizedCursor = cursor?.trim()
+    return normalizedCursor && normalizedCursor !== '0' ? normalizedCursor : undefined
+}
+
 async function getTasksByFilter({
     client,
     query,

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -430,7 +430,7 @@ const ErrorSchema = z.object({
  */
 export function normalizePaginationCursor(cursor: string | undefined): string | undefined {
     const normalizedCursor = cursor?.trim()
-    return normalizedCursor && normalizedCursor !== '0' ? normalizedCursor : undefined
+    return normalizedCursor && normalizedCursor !== '0' ? cursor : undefined
 }
 
 async function getTasksByFilter({

--- a/src/tools/find-comments.test.ts
+++ b/src/tools/find-comments.test.ts
@@ -113,6 +113,21 @@ describe(`${FIND_COMMENTS} tool`, () => {
                 }),
             )
         })
+
+        it.each(['   ', '0'])('should omit first-page cursor sentinel %j', async (cursor) => {
+            mockTodoistApi.getComments.mockResolvedValue({
+                results: [],
+                nextCursor: null,
+            })
+
+            await findComments.execute({ taskId: 'task123', cursor }, mockTodoistApi)
+
+            expect(mockTodoistApi.getComments).toHaveBeenCalledWith({
+                taskId: 'task123',
+                cursor: null,
+                limit: 10,
+            })
+        })
     })
 
     describe('finding comments by project', () => {
@@ -157,6 +172,21 @@ describe(`${FIND_COMMENTS} tool`, () => {
                     totalCount: 1,
                 }),
             )
+        })
+
+        it.each(['   ', '0'])('should omit first-page cursor sentinel %j', async (cursor) => {
+            mockTodoistApi.getComments.mockResolvedValue({
+                results: [],
+                nextCursor: null,
+            })
+
+            await findComments.execute({ projectId: 'project456', cursor }, mockTodoistApi)
+
+            expect(mockTodoistApi.getComments).toHaveBeenCalledWith({
+                projectId: 'project456',
+                cursor: null,
+                limit: 10,
+            })
         })
     })
 

--- a/src/tools/find-comments.ts
+++ b/src/tools/find-comments.ts
@@ -1,7 +1,7 @@
 import type { Comment } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { mapComment, resolveInboxProjectId } from '../tool-helpers.js'
+import { mapComment, normalizePaginationCursor, resolveInboxProjectId } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { CommentSchema as CommentOutputSchema } from '../utils/output-schemas.js'
 import { formatNextSteps } from '../utils/response-builders.js'
@@ -47,6 +47,8 @@ const findComments = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
+        const normalizedCursor = normalizePaginationCursor(args.cursor)
+
         // Validate that exactly one search parameter is provided
         const searchParams = [args.taskId, args.projectId, args.commentId].filter(Boolean)
         if (searchParams.length === 0) {
@@ -76,7 +78,7 @@ const findComments = {
             // Get comments by task
             const response = await client.getComments({
                 taskId: args.taskId,
-                cursor: args.cursor || null,
+                cursor: normalizedCursor ?? null,
                 limit: args.limit || ApiLimits.COMMENTS_DEFAULT,
             })
             rawComments = response.results
@@ -86,7 +88,7 @@ const findComments = {
             // Get comments by project
             const response = await client.getComments({
                 projectId: resolvedProjectId,
-                cursor: args.cursor || null,
+                cursor: normalizedCursor ?? null,
                 limit: args.limit || ApiLimits.COMMENTS_DEFAULT,
             })
             rawComments = response.results

--- a/src/tools/find-completed-tasks.test.ts
+++ b/src/tools/find-completed-tasks.test.ts
@@ -123,6 +123,28 @@ describe(`${FIND_COMPLETED_TASKS} tool`, () => {
             expect(result.textContent).toMatchSnapshot()
         })
 
+        it.each(['', '   ', '0'])('should omit first-page cursor sentinel %j', async (cursor) => {
+            mockTodoistApi.getCompletedTasksByCompletionDate.mockResolvedValue({
+                items: [],
+                nextCursor: null,
+            })
+
+            await findCompletedTasks.execute(
+                {
+                    getBy: 'completion',
+                    limit: 50,
+                    cursor,
+                    labels: [],
+                    labelsOperator: 'or' as const,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getCompletedTasksByCompletionDate).toHaveBeenCalledWith(
+                expect.not.objectContaining({ cursor: expect.anything() }),
+            )
+        })
+
         it('should allow missing since/until and default to the last 7 days', async () => {
             vi.useFakeTimers()
             vi.setSystemTime(new Date('2026-03-03T12:00:00Z'))

--- a/src/tools/find-completed-tasks.test.ts
+++ b/src/tools/find-completed-tasks.test.ts
@@ -327,6 +327,28 @@ describe(`${FIND_COMPLETED_TASKS} tool`, () => {
 
             expect(result.textContent).toMatchSnapshot()
         })
+
+        it('should omit a first-page cursor sentinel', async () => {
+            mockTodoistApi.getCompletedTasksByDueDate.mockResolvedValue({
+                items: [],
+                nextCursor: null,
+            })
+
+            await findCompletedTasks.execute(
+                {
+                    getBy: 'due',
+                    limit: 50,
+                    cursor: '0',
+                    labels: [],
+                    labelsOperator: 'or' as const,
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getCompletedTasksByDueDate).toHaveBeenCalledWith(
+                expect.not.objectContaining({ cursor: expect.anything() }),
+            )
+        })
     })
 
     describe('label filtering', () => {

--- a/src/tools/find-completed-tasks.ts
+++ b/src/tools/find-completed-tasks.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 import { appendToQuery, resolveResponsibleUser } from '../filter-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
-import { mapTask, resolveInboxProjectId } from '../tool-helpers.js'
+import { mapTask, normalizePaginationCursor, resolveInboxProjectId } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { getDateInOffset, parseGmtOffsetToMinutes, shiftDateStringByDays } from '../utils/date.js'
 import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
@@ -116,13 +116,23 @@ const findCompletedTasks = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
-        const { getBy, labels, labelsOperator, since, until, responsibleUser, projectId, ...rest } =
-            args
+        const {
+            getBy,
+            labels,
+            labelsOperator,
+            since,
+            until,
+            responsibleUser,
+            projectId,
+            cursor,
+            ...rest
+        } = args
+        const normalizedCursor = normalizePaginationCursor(cursor)
 
         // Cursor pagination must keep the exact same date window as page 1.
         // If since/until are omitted, they are recomputed from "today" and can drift
         // after midnight between requests, causing inconsistent pagination.
-        if (args.cursor && (!since || !until)) {
+        if (normalizedCursor && (!since || !until)) {
             throw new Error(
                 'Cursor pagination requires explicit since and until. Reuse structuredContent.appliedFilters.since and structuredContent.appliedFilters.until from the previous page.',
             )
@@ -174,6 +184,7 @@ const findCompletedTasks = {
             getBy === 'completion'
                 ? await client.getCompletedTasksByCompletionDate({
                       ...rest,
+                      ...(normalizedCursor ? { cursor: normalizedCursor } : {}),
                       projectId: resolvedProjectId,
                       since: sinceDateTime,
                       until: untilDateTime,
@@ -181,6 +192,7 @@ const findCompletedTasks = {
                   })
                 : await client.getCompletedTasksByDueDate({
                       ...rest,
+                      ...(normalizedCursor ? { cursor: normalizedCursor } : {}),
                       projectId: resolvedProjectId,
                       since: sinceDateTime,
                       until: untilDateTime,

--- a/src/tools/find-tasks-by-date.test.ts
+++ b/src/tools/find-tasks-by-date.test.ts
@@ -241,6 +241,19 @@ describe(`${FIND_TASKS_BY_DATE} tool`, () => {
                 limit: expectedLimit,
             })
         })
+
+        it.each(['', '   ', '0'])('should omit first-page cursor sentinel %j', async (cursor) => {
+            mockGetTasksByFilter.mockResolvedValue({ tasks: [], nextCursor: null })
+
+            await findTasksByDate.execute(
+                { startDate: 'today', limit: 10, daysCount: 1, cursor },
+                mockTodoistApi,
+            )
+
+            expect(mockGetTasksByFilter).toHaveBeenCalledWith(
+                expect.objectContaining({ cursor: undefined }),
+            )
+        })
     })
 
     describe('edge cases', () => {

--- a/src/tools/find-tasks-by-date.ts
+++ b/src/tools/find-tasks-by-date.ts
@@ -7,7 +7,7 @@ import {
     resolveResponsibleUser,
 } from '../filter-helpers.js'
 import type { TodoistTool } from '../todoist-tool.js'
-import { getTasksByFilter } from '../tool-helpers.js'
+import { getTasksByFilter, normalizePaginationCursor } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { generateLabelsFilter, LabelsSchema } from '../utils/labels.js'
 import { TaskSchema as TaskOutputSchema } from '../utils/output-schemas.js'
@@ -89,6 +89,8 @@ const findTasksByDate = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
+        const normalizedCursor = normalizePaginationCursor(args.cursor)
+
         if (!args.startDate && args.overdueOption !== 'overdue-only') {
             throw new Error(
                 'Either startDate must be provided or overdueOption must be set to overdue-only',
@@ -153,7 +155,7 @@ const findTasksByDate = {
         const { tasks, nextCursor } = await getTasksByFilter({
             client,
             query,
-            cursor: args.cursor,
+            cursor: normalizedCursor,
             limit: args.limit,
         })
 

--- a/src/tools/find-tasks.test.ts
+++ b/src/tools/find-tasks.test.ts
@@ -50,6 +50,7 @@ const mockResolveUserNameToId = resolveUserNameToId as MockedFunction<typeof res
 // Mock the Todoist API
 const mockTodoistApi = {
     getTasks: vi.fn(),
+    getTasksByFilter: vi.fn(),
     getUser: vi.fn(),
 } as unknown as Mocked<TodoistApi>
 
@@ -363,6 +364,25 @@ describe(`${FIND_TASKS} tool`, () => {
             const structuredContent = result.structuredContent
             expect(structuredContent.hasMore).toBe(true)
             expect(structuredContent.nextCursor).toBe('next-cursor')
+        })
+
+        it('should omit a first-page cursor sentinel from container queries', async () => {
+            mockTodoistApi.getTasks.mockResolvedValue(createMockApiResponse([]))
+
+            await findTasks.execute(
+                {
+                    projectId: TEST_IDS.PROJECT_TEST,
+                    limit: 10,
+                    cursor: '0',
+                },
+                mockTodoistApi,
+            )
+
+            expect(mockTodoistApi.getTasks).toHaveBeenCalledWith({
+                limit: 10,
+                cursor: null,
+                projectId: TEST_IDS.PROJECT_TEST,
+            })
         })
     })
 
@@ -955,6 +975,30 @@ End of test content.`
         })
 
         describe('when responsibleUser is provided', () => {
+            it('should omit a first-page cursor sentinel from responsible-user-only queries', async () => {
+                mockResolveUserNameToId.mockResolvedValue({
+                    userId: 'specific-user-id',
+                    displayName: 'John Doe',
+                    email: 'john@example.com',
+                })
+                mockTodoistApi.getTasksByFilter.mockResolvedValue({
+                    results: [],
+                    nextCursor: null,
+                })
+
+                await findTasks.execute(
+                    { responsibleUser: 'John Doe', limit: 10, cursor: '0' },
+                    mockTodoistApi,
+                )
+
+                expect(mockTodoistApi.getTasksByFilter).toHaveBeenCalledWith({
+                    query: 'assigned to: john@example.com',
+                    lang: 'en',
+                    limit: 10,
+                    cursor: null,
+                })
+            })
+
             it('should use server-side assignee filter for text search with specified user', async () => {
                 const mockTasks = [
                     createMappedTask({

--- a/src/tools/find-tasks.test.ts
+++ b/src/tools/find-tasks.test.ts
@@ -19,6 +19,7 @@ vi.mock('../tool-helpers', async () => {
     return {
         getTasksByFilter: vi.fn(),
         mapTask: actual.mapTask,
+        normalizePaginationCursor: actual.normalizePaginationCursor,
         filterTasksByResponsibleUser: actual.filterTasksByResponsibleUser,
         RESPONSIBLE_USER_FILTERING: actual.RESPONSIBLE_USER_FILTERING,
         resolveInboxProjectId: actual.resolveInboxProjectId,
@@ -172,6 +173,22 @@ describe(`${FIND_TASKS} tool`, () => {
                     expect.objectContaining({
                         tasks: expect.any(Array),
                     }),
+                )
+            },
+        )
+
+        it.each(['', '   ', '0'])(
+            'should omit first-page cursor sentinel %j from filter queries',
+            async (cursor) => {
+                mockGetTasksByFilter.mockResolvedValue({ tasks: [], nextCursor: null })
+
+                await findTasks.execute(
+                    { searchText: 'project update', limit: 10, cursor },
+                    mockTodoistApi,
+                )
+
+                expect(mockGetTasksByFilter).toHaveBeenCalledWith(
+                    expect.objectContaining({ cursor: undefined }),
                 )
             },
         )

--- a/src/tools/find-tasks.ts
+++ b/src/tools/find-tasks.ts
@@ -12,6 +12,7 @@ import {
     getTasksByFilter,
     type MappedTask,
     mapTask,
+    normalizePaginationCursor,
     resolveInboxProjectId,
 } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
@@ -105,6 +106,7 @@ const findTasks = {
             filter,
             filterIdOrName,
         } = args
+        const normalizedCursor = normalizePaginationCursor(cursor)
 
         const todoistUser = await client.getUser()
 
@@ -153,7 +155,7 @@ const findTasks = {
         if (projectId || sectionId || parentId) {
             const taskParams: GetTasksArgs = {
                 limit,
-                cursor: cursor ?? null,
+                cursor: normalizedCursor ?? null,
             }
 
             if (projectId) {
@@ -226,7 +228,7 @@ const findTasks = {
                 query: responsibleUserFilter,
                 lang: 'en',
                 limit,
-                cursor: cursor ?? null,
+                cursor: normalizedCursor ?? null,
             })
 
             const mappedTasks = tasks.map(mapTask)
@@ -283,7 +285,7 @@ const findTasks = {
         const { tasks: filteredTasks, nextCursor } = await getTasksByFilter({
             client,
             query,
-            cursor: args.cursor,
+            cursor: normalizedCursor,
             limit: args.limit,
         })
 


### PR DESCRIPTION
# Pull Request

Closes #594

## Short description

Paginated task tools currently forward empty cursor values to the Todoist API, which rejects them with an invalid argument error. Schema-driven clients can emit an empty string or `"0"` when they mean the first page, and the same compatibility issue affects paginated comment queries.

This change treats empty, whitespace-only, and `"0"` cursors as an omitted first-page cursor across `find-tasks`, `find-tasks-by-date`, `find-completed-tasks`, and `find-comments`. Valid opaque pagination cursors continue unchanged, including any leading or trailing whitespace.

## PR Checklist

Feel free to leave unchecked or remove the lines that are not applicable.

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.) — Not needed for this runtime normalization.
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`. — Not applicable.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
