### PR TITLE
perf: cache MCP tool schemas

### DIFF
--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -157,6 +157,40 @@ describe('registerTool config', () => {
             value: { limit: 10 },
         })
     })
+
+    it('preserves the uncached side of piped input and output schemas', () => {
+        const { mock, server, client } = captureRegisterToolMock()
+        const pipedDate = z.string().pipe(z.iso.date())
+        const tool = buildToolFixture({
+            name: 'piped-schema-tool',
+            description: 'Tool with different input and output schemas',
+            parameters: { date: pipedDate },
+            outputSchema: { date: pipedDate },
+            execute: async () => ({ textContent: 'ok' }),
+        })
+
+        registerTool({ tool, server, client })
+
+        type SchemaConfig = {
+            inputSchema: StandardSchemaWithJSON<unknown, unknown>
+            outputSchema: StandardSchemaWithJSON<unknown, unknown>
+        }
+        const config = mock.mock.calls[0]?.[1] as SchemaConfig
+        const options = { target: 'draft-2020-12' as const }
+
+        expect(config.inputSchema['~standard'].jsonSchema.input(options)).not.toMatchObject({
+            properties: { date: { format: 'date' } },
+        })
+        expect(config.inputSchema['~standard'].jsonSchema.output(options)).toMatchObject({
+            properties: { date: { format: 'date' } },
+        })
+        expect(config.outputSchema['~standard'].jsonSchema.input(options)).not.toMatchObject({
+            properties: { date: { format: 'date' } },
+        })
+        expect(config.outputSchema['~standard'].jsonSchema.output(options)).toMatchObject({
+            properties: { date: { format: 'date' } },
+        })
+    })
 })
 
 describe('registerTool error path', () => {

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -191,6 +191,36 @@ describe('registerTool config', () => {
             properties: { date: { format: 'date' } },
         })
     })
+
+    it('delegates conversions that do not match the cached options', () => {
+        const { mock, server, client } = captureRegisterToolMock()
+        const parameters = { tuple: z.tuple([z.string(), z.number()]) }
+        const tool = buildToolFixture({
+            parameters,
+            execute: async () => ({ textContent: 'ok' }),
+        })
+
+        registerTool({ tool, server, client })
+
+        const config = mock.mock.calls[0]?.[1] as {
+            inputSchema: StandardSchemaWithJSON<unknown, unknown>
+        }
+        const converter = config.inputSchema['~standard'].jsonSchema.input
+
+        expect(converter({ target: 'draft-07' })).toEqual(
+            z.toJSONSchema(z.object(parameters), { target: 'draft-07', io: 'input' }),
+        )
+
+        const withLibraryOptions = converter({
+            target: 'draft-2020-12',
+            libraryOptions: {
+                override: (context: { jsonSchema: Record<string, unknown> }) => {
+                    context.jsonSchema.description = 'custom conversion'
+                },
+            },
+        })
+        expect(withLibraryOptions.description).toBe('custom conversion')
+    })
 })
 
 describe('registerTool error path', () => {

--- a/src/mcp-helpers.test.ts
+++ b/src/mcp-helpers.test.ts
@@ -1,5 +1,5 @@
 import type { TodoistApi } from '@doist/todoist-sdk'
-import type { ContentBlock } from '@modelcontextprotocol/server'
+import type { ContentBlock, StandardSchemaWithJSON } from '@modelcontextprotocol/server'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { z } from 'zod'
 import { registerTool, stripEmailsFromObject, stripEmailsFromText } from './mcp-helpers.js'
@@ -16,15 +16,22 @@ type ToolFixture = RegisterToolArgs['tool']
 function buildToolFixture(overrides: {
     name?: string
     description?: string
+    parameters?: Record<string, unknown>
     outputSchema?: Record<string, unknown>
     execute: ToolFixture['execute']
 }): ToolFixture {
-    const { name = 'test-tool', description = 'Test tool', outputSchema, execute } = overrides
+    const {
+        name = 'test-tool',
+        description = 'Test tool',
+        parameters = {},
+        outputSchema,
+        execute,
+    } = overrides
 
     return {
         name,
         description,
-        parameters: {},
+        parameters,
         ...(outputSchema ? { outputSchema } : {}),
         annotations: {
             readOnlyHint: true,
@@ -115,25 +122,40 @@ describe('registerTool config', () => {
         expect(Object.hasOwn(config, 'outputSchema')).toBe(false)
     })
 
-    it('includes outputSchema when the tool declares one', () => {
+    it('includes cached standard schemas when the tool declares an output', async () => {
         const { mock, server, client } = captureRegisterToolMock()
         const outputSchema = { value: z.string() }
+        const tool = buildToolFixture({
+            name: 'schema-tool',
+            description: 'Tool with output schema',
+            parameters: { limit: z.number().default(10) },
+            outputSchema,
+            execute: async () => ({ textContent: 'ok' }),
+        })
 
         registerTool({
-            tool: buildToolFixture({
-                name: 'schema-tool',
-                description: 'Tool with output schema',
-                outputSchema,
-                execute: async () => ({ textContent: 'ok' }),
-            }),
+            tool,
             server,
             client,
         })
+        registerTool({ tool, server, client })
 
-        const config = mock.mock.calls[0]?.[1] as Record<string, unknown>
-        expect(config.inputSchema).toBeInstanceOf(z.ZodObject)
-        expect(config.outputSchema).toBeInstanceOf(z.ZodObject)
-        expect((config.outputSchema as z.ZodObject).shape).toHaveProperty('value')
+        type SchemaConfig = {
+            inputSchema: StandardSchemaWithJSON<unknown, unknown>
+            outputSchema: StandardSchemaWithJSON<unknown, unknown>
+        }
+        const firstConfig = mock.mock.calls[0]?.[1] as SchemaConfig
+        const secondConfig = mock.mock.calls[1]?.[1] as SchemaConfig
+        expect(firstConfig.inputSchema).toBe(secondConfig.inputSchema)
+        expect(firstConfig.outputSchema).toBe(secondConfig.outputSchema)
+        expect(
+            firstConfig.outputSchema['~standard'].jsonSchema.output({
+                target: 'draft-2020-12',
+            }),
+        ).toMatchObject({ type: 'object', properties: { value: { type: 'string' } } })
+        expect(await firstConfig.inputSchema['~standard'].validate({})).toEqual({
+            value: { limit: 10 },
+        })
     })
 })
 

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -4,6 +4,7 @@ import type {
     ToolCallback,
     ContentBlock,
     ToolAnnotations,
+    StandardSchemaWithJSON,
 } from '@modelcontextprotocol/server'
 import { z } from 'zod'
 import type { AnyTodoistTool, ExecuteResult } from './todoist-tool.js'
@@ -69,6 +70,50 @@ type AppToolMeta =
  */
 const USE_STRUCTURED_CONTENT =
     process.env.USE_STRUCTURED_CONTENT === 'true' || process.env.NODE_ENV === 'test'
+
+type CachedToolSchemas = {
+    input: StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>>
+    output?: StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>>
+}
+
+/** Tool schemas are static, so compile their JSON representation once per process. */
+const TOOL_SCHEMAS = new WeakMap<AnyTodoistTool, CachedToolSchemas>()
+
+function withCachedJsonSchema(
+    schema: z.ZodObject<z.ZodRawShape>,
+    io: 'input' | 'output',
+): StandardSchemaWithJSON<Record<string, unknown>, Record<string, unknown>> {
+    const jsonSchema = z.toJSONSchema(schema, { target: 'draft-2020-12', io })
+    const standard = schema['~standard']
+
+    return {
+        '~standard': {
+            version: 1,
+            vendor: standard.vendor,
+            validate: (value) => standard.validate(value),
+            jsonSchema: {
+                input: () => jsonSchema,
+                output: () => jsonSchema,
+            },
+        },
+    }
+}
+
+function getToolSchemas(tool: AnyTodoistTool): CachedToolSchemas {
+    const cached = TOOL_SCHEMAS.get(tool)
+    if (cached) {
+        return cached
+    }
+
+    const schemas: CachedToolSchemas = {
+        input: withCachedJsonSchema(z.object(tool.parameters), 'input'),
+        ...(tool.outputSchema
+            ? { output: withCachedJsonSchema(z.object(tool.outputSchema), 'output') }
+            : {}),
+    }
+    TOOL_SCHEMAS.set(tool, schemas)
+    return schemas
+}
 
 /**
  * Get the output payload for a tool, in the correct format expected by MCP client apps.
@@ -280,8 +325,7 @@ function registerTool({
         client: TodoistApi,
     ) => ExecuteResult<z.ZodRawShape>
 
-    const inputSchema = z.object(tool.parameters)
-    const outputSchema = tool.outputSchema ? z.object(tool.outputSchema) : undefined
+    const { input: inputSchema, output: outputSchema } = getToolSchemas(tool)
 
     // `getToolOutput` assembles its result incrementally and so is typed as a
     // plain record, which does not structurally match `CallToolResult` (that

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -88,12 +88,10 @@ function withCachedJsonSchema(
 
     return {
         '~standard': {
-            version: 1,
-            vendor: standard.vendor,
-            validate: (value) => standard.validate(value),
+            ...standard,
             jsonSchema: {
-                input: () => jsonSchema,
-                output: () => jsonSchema,
+                ...standard.jsonSchema,
+                [io]: () => jsonSchema,
             },
         },
     }

--- a/src/mcp-helpers.ts
+++ b/src/mcp-helpers.ts
@@ -91,7 +91,10 @@ function withCachedJsonSchema(
             ...standard,
             jsonSchema: {
                 ...standard.jsonSchema,
-                [io]: () => jsonSchema,
+                [io]: (options: Parameters<typeof standard.jsonSchema.input>[0]) =>
+                    options.target === 'draft-2020-12' && options.libraryOptions === undefined
+                        ? jsonSchema
+                        : standard.jsonSchema[io](options),
             },
         },
     }

--- a/src/tool-schema-dialect.test.ts
+++ b/src/tool-schema-dialect.test.ts
@@ -1,31 +1,62 @@
 import { Client, InMemoryTransport } from '@modelcontextprotocol/client'
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 import { getMcpServer } from './mcp-server.js'
 import { registeredTools } from './tool-registry.js'
 
 const JSON_SCHEMA_2020_12 = 'https://json-schema.org/draft/2020-12/schema'
 
+async function listAdvertisedTools() {
+    const server = getMcpServer({ todoistApiKey: 'test-token' })
+    const client = new Client({ name: 'schema-dialect-test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+
+    try {
+        return (await client.listTools()).tools
+    } finally {
+        await client.close()
+        await server.close()
+    }
+}
+
 describe('advertised tool schema dialects', () => {
     it('uses JSON Schema 2020-12 for every tool schema', async () => {
-        const server = getMcpServer({ todoistApiKey: 'test-token' })
-        const client = new Client({ name: 'schema-dialect-test', version: '1.0.0' })
-        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+        const tools = await listAdvertisedTools()
 
-        await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
-
-        try {
-            const { tools } = await client.listTools()
-
-            expect(tools).toHaveLength(registeredTools.length)
-            for (const tool of tools) {
-                expect(tool.inputSchema.$schema).toBe(JSON_SCHEMA_2020_12)
-                if (tool.outputSchema) {
-                    expect(tool.outputSchema.$schema).toBe(JSON_SCHEMA_2020_12)
-                }
+        expect(tools).toHaveLength(registeredTools.length)
+        for (const tool of tools) {
+            expect(tool.inputSchema.$schema).toBe(JSON_SCHEMA_2020_12)
+            if (tool.outputSchema) {
+                expect(tool.outputSchema.$schema).toBe(JSON_SCHEMA_2020_12)
             }
-        } finally {
-            await client.close()
-            await server.close()
+        }
+    })
+
+    it('matches direct Zod conversion for every registered tool', async () => {
+        const toolsByName = new Map((await listAdvertisedTools()).map((tool) => [tool.name, tool]))
+
+        for (const tool of registeredTools) {
+            const advertised = toolsByName.get(tool.name)
+            expect(advertised, `missing advertised tool ${tool.name}`).toBeDefined()
+            expect(advertised?.inputSchema).toEqual(
+                z.toJSONSchema(z.object(tool.parameters), {
+                    target: 'draft-2020-12',
+                    io: 'input',
+                }),
+            )
+
+            if (tool.outputSchema) {
+                expect(advertised?.outputSchema).toEqual(
+                    z.toJSONSchema(z.object(tool.outputSchema), {
+                        target: 'draft-2020-12',
+                        io: 'output',
+                    }),
+                )
+            } else {
+                expect(advertised?.outputSchema).toBeUndefined()
+            }
         }
     })
 })


### PR DESCRIPTION
## Short description

The hosted integration creates an isolated MCP server for each request. Registering its 47 tools previously converted the same static Zod schemas to JSON Schema each time. This repeated a small amount of CPU work and created short-lived objects on every request.

This change compiles each tool's input and output schema once per process and reuses that immutable representation when later server instances register the tool. The cache applies only to the draft 2020-12 conversion with default options, which is what the current MCP SDK requests. Other JSON Schema targets or custom library options still delegate to Zod, so a future SDK change cannot receive a cached schema in the wrong dialect.

Requests still receive separate MCP servers and request-scoped clients, so user state, validation, and concurrent requests remain isolated. Validation continues to use the original Zod schema.

A local benchmark measured registration at about 3.4 ms before this change and 0.2 ms after it, with roughly 120 KB less short-lived JSON data per server creation. This is a small cleanup of repeated work. It is not expected by itself to produce a visible latency change or explain the earlier incident.

## Verification

- Confirms that repeated registrations reuse separate cached input and output conversions.
- Confirms that other schema dialects and custom library options delegate to Zod.
- Confirms through a real MCP `tools/list` request that every advertised tool schema matches direct Zod conversion.
- Full test suite: 1,264 tests passed.

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
