### PR TITLE
fix: bound per-account concurrency limiters

### DIFF
--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -248,20 +248,29 @@ describe('createLimiter', () => {
 describe('per-account limiters', () => {
     it('should bound retained account limiters', () => {
         for (let index = 0; index < 10_001; index++) {
-            registerClientLimiters({}, `token-${index}`)
+            const client = {}
+            registerClientLimiters(client, `token-${index}`)
+            getMoveLimiter(client)
         }
 
         expect(getAccountLimiterCountForTesting()).toBe(10_000)
     })
 
-    it('should share concurrency limits across clients after the registry reaches capacity', async () => {
-        for (let index = 0; index < 10_000; index++) {
-            registerClientLimiters({}, `retained-token-${index}`)
+    it('should evict idle entries before using overflow', async () => {
+        resetLimitersForTesting({ maxAccountLimiters: 2 })
+
+        for (const token of ['retained-token-1', 'retained-token-2']) {
+            const client = {}
+            registerClientLimiters(client, token)
+            getMoveLimiter(client)
         }
+
         const clientA = {}
         const clientB = {}
-        registerClientLimiters(clientA, 'overflow-token')
-        registerClientLimiters(clientB, 'overflow-token')
+        registerClientLimiters(clientA, 'new-token-1')
+        registerClientLimiters(clientB, 'new-token-2')
+        const limiterA = getMoveLimiter(clientA)
+        const limiterB = getMoveLimiter(clientB)
 
         const gate = deferred()
         let active = 0
@@ -273,8 +282,45 @@ describe('per-account limiters', () => {
             active--
         }
 
-        const first = getMoveLimiter(clientA)(() => track(gate.promise))
-        const second = getMoveLimiter(clientB)(() => track(Promise.resolve()))
+        const first = limiterA(() => track(gate.promise))
+        const second = limiterB(() => track(Promise.resolve()))
+
+        await flush()
+        expect(maxActive).toBe(2)
+
+        gate.resolve()
+        await Promise.all([first, second])
+    })
+
+    it('should re-resolve a client whose idle entry was evicted', async () => {
+        resetLimitersForTesting({ maxAccountLimiters: 2 })
+
+        const originalClient = {}
+        registerClientLimiters(originalClient, 'token-1')
+        const originalLimiter = getMoveLimiter(originalClient)
+
+        for (const token of ['token-2', 'token-3']) {
+            const client = {}
+            registerClientLimiters(client, token)
+            getMoveLimiter(client)
+        }
+
+        const replacementClient = {}
+        registerClientLimiters(replacementClient, 'token-1')
+        const replacementLimiter = getMoveLimiter(replacementClient)
+
+        const gate = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (waitFor: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await waitFor
+            active--
+        }
+
+        const first = originalLimiter(() => track(gate.promise))
+        const second = replacementLimiter(() => track(Promise.resolve()))
 
         await flush()
         expect(maxActive).toBe(ConcurrencyLimits.TASK_MOVES)
@@ -283,10 +329,55 @@ describe('per-account limiters', () => {
         await Promise.all([first, second])
     })
 
-    it('should keep overflow clients separate from unregistered clients', async () => {
-        for (let index = 0; index < 10_000; index++) {
-            registerClientLimiters({}, `retained-token-${index}`)
+    it('should use shared overflow limiters when every retained entry is busy', async () => {
+        resetLimitersForTesting({ maxAccountLimiters: 2 })
+
+        const busyGate = deferred()
+        const busyTasks = ['busy-token-1', 'busy-token-2'].map((token) => {
+            const client = {}
+            registerClientLimiters(client, token)
+            return getMoveLimiter(client)(() => busyGate.promise)
+        })
+        await flush()
+
+        const clientA = {}
+        const clientB = {}
+        registerClientLimiters(clientA, 'overflow-token-1')
+        registerClientLimiters(clientB, 'overflow-token-2')
+        const limiterA = getMoveLimiter(clientA)
+        const limiterB = getMoveLimiter(clientB)
+
+        const overflowGate = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (waitFor: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await waitFor
+            active--
         }
+
+        const first = limiterA(() => track(overflowGate.promise))
+        const second = limiterB(() => track(Promise.resolve()))
+
+        await flush()
+        expect(maxActive).toBe(ConcurrencyLimits.TASK_MOVES)
+
+        overflowGate.resolve()
+        await Promise.all([first, second])
+        busyGate.resolve()
+        await Promise.all(busyTasks)
+    })
+
+    it('should keep overflow clients separate from unregistered clients', async () => {
+        resetLimitersForTesting({ maxAccountLimiters: 1 })
+
+        const busyClient = {}
+        registerClientLimiters(busyClient, 'busy-token')
+        const busyGate = deferred()
+        const busyTask = getMoveLimiter(busyClient)(() => busyGate.promise)
+        await flush()
+
         const overflowClient = {}
         registerClientLimiters(overflowClient, 'overflow-token')
 
@@ -308,14 +399,20 @@ describe('per-account limiters', () => {
 
         gate.resolve()
         await Promise.all([overflowTask, fallbackTask])
+        busyGate.resolve()
+        await busyTask
     })
 
     it('should remove expired idle account limiters', () => {
         vi.useFakeTimers()
-        registerClientLimiters({}, 'old-token')
+        const oldClient = {}
+        registerClientLimiters(oldClient, 'old-token')
+        getMoveLimiter(oldClient)
 
         vi.advanceTimersByTime(5 * 60_000)
-        registerClientLimiters({}, 'new-token')
+        const newClient = {}
+        registerClientLimiters(newClient, 'new-token')
+        getMoveLimiter(newClient)
 
         expect(getAccountLimiterCountForTesting()).toBe(1)
         vi.useRealTimers()
@@ -329,7 +426,9 @@ describe('per-account limiters', () => {
         const task = getMoveLimiter(client)(() => gate.promise)
         await vi.advanceTimersByTimeAsync(5 * 60_000)
 
-        registerClientLimiters({}, 'new-token')
+        const newClient = {}
+        registerClientLimiters(newClient, 'new-token')
+        getMoveLimiter(newClient)
         expect(getAccountLimiterCountForTesting()).toBe(2)
 
         gate.resolve()

--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -1,6 +1,5 @@
 import {
     createLimiter,
-    getAccountLimiterCountForTesting,
     getMoveLimiter,
     getWriteLimiter,
     registerClientLimiters,
@@ -246,16 +245,6 @@ describe('createLimiter', () => {
 })
 
 describe('per-account limiters', () => {
-    it('should bound retained account limiters', () => {
-        for (let index = 0; index < 10_001; index++) {
-            const client = {}
-            registerClientLimiters(client, `token-${index}`)
-            getMoveLimiter(client)
-        }
-
-        expect(getAccountLimiterCountForTesting()).toBe(10_000)
-    })
-
     it('should evict idle entries before using overflow', async () => {
         resetLimitersForTesting({ maxAccountLimiters: 2 })
 
@@ -403,37 +392,44 @@ describe('per-account limiters', () => {
         await busyTask
     })
 
-    it('should remove expired idle account limiters', () => {
+    it('should keep an expired active account on the same limiter', async () => {
         vi.useFakeTimers()
-        const oldClient = {}
-        registerClientLimiters(oldClient, 'old-token')
-        getMoveLimiter(oldClient)
-
-        vi.advanceTimersByTime(5 * 60_000)
-        const newClient = {}
-        registerClientLimiters(newClient, 'new-token')
-        getMoveLimiter(newClient)
-
-        expect(getAccountLimiterCountForTesting()).toBe(1)
-        vi.useRealTimers()
-    })
-
-    it('should retain an expired limiter while it has active work', async () => {
-        vi.useFakeTimers()
-        const client = {}
-        registerClientLimiters(client, 'busy-token')
         const gate = deferred()
-        const task = getMoveLimiter(client)(() => gate.promise)
-        await vi.advanceTimersByTimeAsync(5 * 60_000)
+        try {
+            resetLimitersForTesting({ maxAccountLimiters: 1 })
 
-        const newClient = {}
-        registerClientLimiters(newClient, 'new-token')
-        getMoveLimiter(newClient)
-        expect(getAccountLimiterCountForTesting()).toBe(2)
+            let active = 0
+            let maxActive = 0
+            const track = async (waitFor: Promise<void>) => {
+                active++
+                maxActive = Math.max(maxActive, active)
+                await waitFor
+                active--
+            }
 
-        gate.resolve()
-        await task
-        vi.useRealTimers()
+            const originalClient = {}
+            registerClientLimiters(originalClient, 'busy-token')
+            const first = getMoveLimiter(originalClient)(() => track(gate.promise))
+            await vi.advanceTimersByTimeAsync(5 * 60_000)
+
+            // Trigger capacity pressure after the active entry's TTL expires.
+            const otherClient = {}
+            registerClientLimiters(otherClient, 'other-token')
+            getMoveLimiter(otherClient)
+
+            const concurrentClient = {}
+            registerClientLimiters(concurrentClient, 'busy-token')
+            const second = getMoveLimiter(concurrentClient)(() => track(Promise.resolve()))
+
+            await vi.advanceTimersByTimeAsync(0)
+            expect(maxActive).toBe(ConcurrencyLimits.TASK_MOVES)
+
+            gate.resolve()
+            await Promise.all([first, second])
+        } finally {
+            gate.resolve()
+            vi.useRealTimers()
+        }
     })
 
     it('should share limiters across clients registered for the same account', async () => {

--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -1,5 +1,6 @@
 import {
     createLimiter,
+    getAccountLimiterCountForTesting,
     getMoveLimiter,
     getWriteLimiter,
     registerClientLimiters,
@@ -245,6 +246,41 @@ describe('createLimiter', () => {
 })
 
 describe('per-account limiters', () => {
+    it('should bound retained account limiters', () => {
+        for (let index = 0; index < 10_001; index++) {
+            registerClientLimiters({}, `token-${index}`)
+        }
+
+        expect(getAccountLimiterCountForTesting()).toBe(10_000)
+    })
+
+    it('should remove expired idle account limiters', () => {
+        vi.useFakeTimers()
+        registerClientLimiters({}, 'old-token')
+
+        vi.advanceTimersByTime(5 * 60_000)
+        registerClientLimiters({}, 'new-token')
+
+        expect(getAccountLimiterCountForTesting()).toBe(1)
+        vi.useRealTimers()
+    })
+
+    it('should retain an expired limiter while it has active work', async () => {
+        vi.useFakeTimers()
+        const client = {}
+        registerClientLimiters(client, 'busy-token')
+        const gate = deferred()
+        const task = getMoveLimiter(client)(() => gate.promise)
+        await vi.advanceTimersByTimeAsync(5 * 60_000)
+
+        registerClientLimiters({}, 'new-token')
+        expect(getAccountLimiterCountForTesting()).toBe(2)
+
+        gate.resolve()
+        await task
+        vi.useRealTimers()
+    })
+
     it('should share limiters across clients registered for the same account', async () => {
         const clientA = {}
         const clientB = {}

--- a/src/utils/concurrency.test.ts
+++ b/src/utils/concurrency.test.ts
@@ -254,6 +254,62 @@ describe('per-account limiters', () => {
         expect(getAccountLimiterCountForTesting()).toBe(10_000)
     })
 
+    it('should share concurrency limits across clients after the registry reaches capacity', async () => {
+        for (let index = 0; index < 10_000; index++) {
+            registerClientLimiters({}, `retained-token-${index}`)
+        }
+        const clientA = {}
+        const clientB = {}
+        registerClientLimiters(clientA, 'overflow-token')
+        registerClientLimiters(clientB, 'overflow-token')
+
+        const gate = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (waitFor: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await waitFor
+            active--
+        }
+
+        const first = getMoveLimiter(clientA)(() => track(gate.promise))
+        const second = getMoveLimiter(clientB)(() => track(Promise.resolve()))
+
+        await flush()
+        expect(maxActive).toBe(ConcurrencyLimits.TASK_MOVES)
+
+        gate.resolve()
+        await Promise.all([first, second])
+    })
+
+    it('should keep overflow clients separate from unregistered clients', async () => {
+        for (let index = 0; index < 10_000; index++) {
+            registerClientLimiters({}, `retained-token-${index}`)
+        }
+        const overflowClient = {}
+        registerClientLimiters(overflowClient, 'overflow-token')
+
+        const gate = deferred()
+        let active = 0
+        let maxActive = 0
+        const track = async (waitFor: Promise<void>) => {
+            active++
+            maxActive = Math.max(maxActive, active)
+            await waitFor
+            active--
+        }
+
+        const overflowTask = getMoveLimiter(overflowClient)(() => track(gate.promise))
+        const fallbackTask = getMoveLimiter({})(() => track(Promise.resolve()))
+
+        await flush()
+        expect(maxActive).toBe(2)
+
+        gate.resolve()
+        await Promise.all([overflowTask, fallbackTask])
+    })
+
     it('should remove expired idle account limiters', () => {
         vi.useFakeTimers()
         registerClientLimiters({}, 'old-token')

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -4,7 +4,11 @@ import { ConcurrencyLimits } from './constants.js'
 /**
  * Wraps a task so it only runs once a slot is free.
  */
-type Limiter = <T>(fn: () => Promise<T>) => Promise<T>
+type Limiter = {
+    <T>(fn: () => Promise<T>): Promise<T>
+    /** Whether no task is running or waiting for this limiter. */
+    isIdle: () => boolean
+}
 
 type LimiterPair = {
     /** Serialises task-move requests, which contend on server-side tree locks. */
@@ -89,7 +93,7 @@ function createLimiter(
         active--
     }
 
-    return async function limit<T>(fn: () => Promise<T>): Promise<T> {
+    const limit = async function limit<T>(fn: () => Promise<T>): Promise<T> {
         await acquire()
         try {
             return await fn()
@@ -98,6 +102,8 @@ function createLimiter(
             release()
         }
     }
+    limit.isIdle = () => active === 0 && queue.length === 0
+    return limit
 }
 
 function createLimiterPair(): LimiterPair {
@@ -115,7 +121,14 @@ function createLimiterPair(): LimiterPair {
  * This map lives in one process, so the limits it enforces are per process rather
  * than per account globally. See the note on `ConcurrencyLimits`.
  */
-const limitersByAccount = new Map<string, LimiterPair>()
+type AccountLimiterEntry = {
+    limiters: LimiterPair
+    lastUsedAt: number
+}
+
+const MAX_ACCOUNT_LIMITERS = 10_000
+const ACCOUNT_LIMITER_IDLE_TTL_MS = 5 * 60_000
+const limitersByAccount = new Map<string, AccountLimiterEntry>()
 
 /** Lets a tool find its account's limiters from the client it was handed. */
 const limitersByClient = new WeakMap<object, LimiterPair>()
@@ -139,18 +152,50 @@ function accountKeyFromApiKey(apiKey: string): string {
     return createHash('sha256').update(apiKey).digest('hex')
 }
 
+function isLimiterPairIdle({ moves, writes }: LimiterPair): boolean {
+    return moves.isIdle() && writes.isIdle()
+}
+
+/**
+ * Removes expired idle entries from the oldest end of the insertion-ordered
+ * map. Active entries stay until their work finishes, even after they expire.
+ */
+function pruneIdleAccountLimiters(now: number): void {
+    for (const [key, entry] of limitersByAccount) {
+        if (now - entry.lastUsedAt < ACCOUNT_LIMITER_IDLE_TTL_MS) {
+            break
+        }
+        if (isLimiterPairIdle(entry.limiters)) {
+            limitersByAccount.delete(key)
+        }
+    }
+}
+
 /**
  * Associates a client with its account's limiters, sharing one pair across every
  * client built for the same account.
  */
 function registerClientLimiters(client: object, apiKey: string): void {
     const key = accountKeyFromApiKey(apiKey)
-    let limiters = limitersByAccount.get(key)
-    if (!limiters) {
-        limiters = createLimiterPair()
-        limitersByAccount.set(key, limiters)
+    const now = Date.now()
+    let entry = limitersByAccount.get(key)
+
+    if (entry) {
+        // Refresh insertion order so pruning can stop at the first fresh entry.
+        limitersByAccount.delete(key)
+        entry.lastUsedAt = now
+        limitersByAccount.set(key, entry)
+    } else {
+        pruneIdleAccountLimiters(now)
+        entry = { limiters: createLimiterPair(), lastUsedAt: now }
+
+        // Keep the registry bounded. If every slot belongs to a recently used
+        // account, the new client still gets local limits but is not retained.
+        if (limitersByAccount.size < MAX_ACCOUNT_LIMITERS) {
+            limitersByAccount.set(key, entry)
+        }
     }
-    limitersByClient.set(client, limiters)
+    limitersByClient.set(client, entry.limiters)
 }
 
 function getLimiters(client: object): LimiterPair {
@@ -171,8 +216,14 @@ function resetLimitersForTesting(): void {
     fallbackLimiters = undefined
 }
 
+/** Test-only: reports retained account entries for bounded-cache assertions. */
+function getAccountLimiterCountForTesting(): number {
+    return limitersByAccount.size
+}
+
 export {
     createLimiter,
+    getAccountLimiterCountForTesting,
     getMoveLimiter,
     getWriteLimiter,
     type Limiter,

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -138,10 +138,16 @@ const limitersByClient = new WeakMap<object, LimiterPair>()
  * every call site is bounded even when nothing registered it.
  */
 let fallbackLimiters: LimiterPair | undefined
+let overflowLimiters: LimiterPair | undefined
 
 function getFallbackLimiters(): LimiterPair {
     fallbackLimiters ??= createLimiterPair()
     return fallbackLimiters
+}
+
+function getOverflowLimiters(): LimiterPair {
+    overflowLimiters ??= createLimiterPair()
+    return overflowLimiters
 }
 
 /**
@@ -179,23 +185,28 @@ function registerClientLimiters(client: object, apiKey: string): void {
     const key = accountKeyFromApiKey(apiKey)
     const now = Date.now()
     let entry = limitersByAccount.get(key)
+    let limiters: LimiterPair
 
     if (entry) {
         // Refresh insertion order so pruning can stop at the first fresh entry.
         limitersByAccount.delete(key)
         entry.lastUsedAt = now
         limitersByAccount.set(key, entry)
+        limiters = entry.limiters
     } else {
         pruneIdleAccountLimiters(now)
-        entry = { limiters: createLimiterPair(), lastUsedAt: now }
 
-        // Keep the registry bounded. If every slot belongs to a recently used
-        // account, the new client still gets local limits but is not retained.
         if (limitersByAccount.size < MAX_ACCOUNT_LIMITERS) {
+            entry = { limiters: createLimiterPair(), lastUsedAt: now }
             limitersByAccount.set(key, entry)
+            limiters = entry.limiters
+        } else {
+            // Do not retain another account, but keep concurrency bounded across
+            // requests by routing every overflow client through one shared pair.
+            limiters = getOverflowLimiters()
         }
     }
-    limitersByClient.set(client, entry.limiters)
+    limitersByClient.set(client, limiters)
 }
 
 function getLimiters(client: object): LimiterPair {
@@ -214,6 +225,7 @@ function getWriteLimiter(client: object): Limiter {
 function resetLimitersForTesting(): void {
     limitersByAccount.clear()
     fallbackLimiters = undefined
+    overflowLimiters = undefined
 }
 
 /** Test-only: reports retained account entries for bounded-cache assertions. */

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -4,17 +4,18 @@ import { ConcurrencyLimits } from './constants.js'
 /**
  * Wraps a task so it only runs once a slot is free.
  */
-type Limiter = {
-    <T>(fn: () => Promise<T>): Promise<T>
+type Limiter = <T>(fn: () => Promise<T>) => Promise<T>
+
+type TrackedLimiter = Limiter & {
     /** Whether no task is running or waiting for this limiter. */
     isIdle: () => boolean
 }
 
 type LimiterPair = {
     /** Serialises task-move requests, which contend on server-side tree locks. */
-    moves: Limiter
+    moves: TrackedLimiter
     /** Bounds all other write requests. */
-    writes: Limiter
+    writes: TrackedLimiter
 }
 
 type QueuedTask = {
@@ -40,7 +41,7 @@ type QueuedTask = {
 function createLimiter(
     maxConcurrent: number,
     { queueTimeoutMs = ConcurrencyLimits.QUEUE_WAIT_MS }: { queueTimeoutMs?: number } = {},
-): Limiter {
+): TrackedLimiter {
     if (!Number.isInteger(maxConcurrent) || maxConcurrent < 1) {
         throw new Error(
             `maxConcurrent must be a positive integer, received ${String(maxConcurrent)}`,
@@ -124,14 +125,19 @@ function createLimiterPair(): LimiterPair {
 type AccountLimiterEntry = {
     limiters: LimiterPair
     lastUsedAt: number
+    leases: number
 }
 
 const MAX_ACCOUNT_LIMITERS = 10_000
 const ACCOUNT_LIMITER_IDLE_TTL_MS = 5 * 60_000
 const limitersByAccount = new Map<string, AccountLimiterEntry>()
+let accountLimiterCapacity = MAX_ACCOUNT_LIMITERS
 
-/** Lets a tool find its account's limiters from the client it was handed. */
-const limitersByClient = new WeakMap<object, LimiterPair>()
+/** Lets a tool resolve its current account entry from the client it was handed. */
+const accountKeysByClient = new WeakMap<object, string>()
+
+/** Keeps an account on overflow until all of its overflow work has finished. */
+const overflowLeasesByAccount = new Map<string, number>()
 
 /**
  * Catches clients built outside `createTodoistClient` (tests, direct SDK use) so
@@ -162,6 +168,16 @@ function isLimiterPairIdle({ moves, writes }: LimiterPair): boolean {
     return moves.isIdle() && writes.isIdle()
 }
 
+function isAccountLimiterEvictable(entry: AccountLimiterEntry): boolean {
+    return entry.leases === 0 && isLimiterPairIdle(entry.limiters)
+}
+
+function refreshAccountLimiter(key: string, entry: AccountLimiterEntry, now: number): void {
+    limitersByAccount.delete(key)
+    entry.lastUsedAt = now
+    limitersByAccount.set(key, entry)
+}
+
 /**
  * Removes expired idle entries from the oldest end of the insertion-ordered
  * map. Active entries stay until their work finishes, even after they expire.
@@ -171,61 +187,132 @@ function pruneIdleAccountLimiters(now: number): void {
         if (now - entry.lastUsedAt < ACCOUNT_LIMITER_IDLE_TTL_MS) {
             break
         }
-        if (isLimiterPairIdle(entry.limiters)) {
+        if (isAccountLimiterEvictable(entry)) {
             limitersByAccount.delete(key)
         }
     }
 }
 
-/**
- * Associates a client with its account's limiters, sharing one pair across every
- * client built for the same account.
- */
-function registerClientLimiters(client: object, apiKey: string): void {
-    const key = accountKeyFromApiKey(apiKey)
-    const now = Date.now()
-    let entry = limitersByAccount.get(key)
-    let limiters: LimiterPair
-
-    if (entry) {
-        // Refresh insertion order so pruning can stop at the first fresh entry.
-        limitersByAccount.delete(key)
-        entry.lastUsedAt = now
-        limitersByAccount.set(key, entry)
-        limiters = entry.limiters
-    } else {
-        pruneIdleAccountLimiters(now)
-
-        if (limitersByAccount.size < MAX_ACCOUNT_LIMITERS) {
-            entry = { limiters: createLimiterPair(), lastUsedAt: now }
-            limitersByAccount.set(key, entry)
-            limiters = entry.limiters
-        } else {
-            // Do not retain another account, but keep concurrency bounded across
-            // requests by routing every overflow client through one shared pair.
-            limiters = getOverflowLimiters()
+/** Evicts the least-recently-used entry that has no running or queued work. */
+function evictOldestIdleAccountLimiter(): boolean {
+    for (const [key, entry] of limitersByAccount) {
+        if (isAccountLimiterEvictable(entry)) {
+            limitersByAccount.delete(key)
+            return true
         }
     }
-    limitersByClient.set(client, limiters)
+    return false
 }
 
-function getLimiters(client: object): LimiterPair {
-    return limitersByClient.get(client) ?? getFallbackLimiters()
+function getOrCreateAccountLimiterEntry(key: string, now: number): AccountLimiterEntry | undefined {
+    // Do not move an account to a dedicated pair while one of its operations is
+    // still using overflow, or concurrent calls could escape each other's limit.
+    if (overflowLeasesByAccount.has(key)) {
+        return undefined
+    }
+
+    const existing = limitersByAccount.get(key)
+    if (existing) {
+        refreshAccountLimiter(key, existing, now)
+        return existing
+    }
+
+    pruneIdleAccountLimiters(now)
+    if (limitersByAccount.size >= accountLimiterCapacity && !evictOldestIdleAccountLimiter()) {
+        return undefined
+    }
+
+    const entry = { limiters: createLimiterPair(), lastUsedAt: now, leases: 0 }
+    limitersByAccount.set(key, entry)
+    return entry
+}
+
+type LimiterPairLease = {
+    limiters: LimiterPair
+    release: () => void
+}
+
+function acquireAccountLimiterPair(key: string): LimiterPairLease {
+    const overflowLeases = overflowLeasesByAccount.get(key)
+    if (overflowLeases !== undefined) {
+        overflowLeasesByAccount.set(key, overflowLeases + 1)
+        return {
+            limiters: getOverflowLimiters(),
+            release: () => releaseOverflowLease(key),
+        }
+    }
+
+    const entry = getOrCreateAccountLimiterEntry(key, Date.now())
+    if (entry) {
+        entry.leases++
+        return {
+            limiters: entry.limiters,
+            release: () => {
+                entry.leases--
+            },
+        }
+    }
+
+    overflowLeasesByAccount.set(key, 1)
+    return {
+        limiters: getOverflowLimiters(),
+        release: () => releaseOverflowLease(key),
+    }
+}
+
+function releaseOverflowLease(key: string): void {
+    const leases = overflowLeasesByAccount.get(key)
+    if (leases === undefined || leases <= 1) {
+        overflowLeasesByAccount.delete(key)
+        return
+    }
+    overflowLeasesByAccount.set(key, leases - 1)
+}
+
+/** Records the account key so each limited operation can resolve its current pair. */
+function registerClientLimiters(client: object, apiKey: string): void {
+    const key = accountKeyFromApiKey(apiKey)
+    accountKeysByClient.set(client, key)
+}
+
+function getClientLimiter(client: object, lane: keyof LimiterPair): Limiter {
+    const key = accountKeysByClient.get(client)
+    if (!key) {
+        return getFallbackLimiters()[lane]
+    }
+
+    // Populate or refresh the entry when the tool selects its lane. The returned
+    // function resolves it again when work starts, so eviction can never leave a
+    // request holding a stale limiter pair.
+    getOrCreateAccountLimiterEntry(key, Date.now())
+
+    return async <T>(fn: () => Promise<T>): Promise<T> => {
+        const lease = acquireAccountLimiterPair(key)
+        try {
+            return await lease.limiters[lane](fn)
+        } finally {
+            lease.release()
+        }
+    }
 }
 
 function getMoveLimiter(client: object): Limiter {
-    return getLimiters(client).moves
+    return getClientLimiter(client, 'moves')
 }
 
 function getWriteLimiter(client: object): Limiter {
-    return getLimiters(client).writes
+    return getClientLimiter(client, 'writes')
 }
 
 /** Test-only: drops all registered limiters so cases start from a clean slate. */
-function resetLimitersForTesting(): void {
+function resetLimitersForTesting({
+    maxAccountLimiters = MAX_ACCOUNT_LIMITERS,
+}: { maxAccountLimiters?: number } = {}): void {
     limitersByAccount.clear()
+    overflowLeasesByAccount.clear()
     fallbackLimiters = undefined
     overflowLimiters = undefined
+    accountLimiterCapacity = maxAccountLimiters
 }
 
 /** Test-only: reports retained account entries for bounded-cache assertions. */

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -315,14 +315,8 @@ function resetLimitersForTesting({
     accountLimiterCapacity = maxAccountLimiters
 }
 
-/** Test-only: reports retained account entries for bounded-cache assertions. */
-function getAccountLimiterCountForTesting(): number {
-    return limitersByAccount.size
-}
-
 export {
     createLimiter,
-    getAccountLimiterCountForTesting,
     getMoveLimiter,
     getWriteLimiter,
     type Limiter,


### PR DESCRIPTION
Related to #596

## Short description

The MCP server creates a new `TodoistApi` client for each HTTP request. To keep task updates safe, clients for the same Todoist account share one pair of concurrency limiters. However, the server previously retained every account's limiter pair for the lifetime of the process. Memory could therefore grow with every distinct account that reached a long-running server instance.

This change makes that registry bounded:

- It removes a per-account limiter entry after five minutes of inactivity, but only when the limiter has no running or queued work.
- It retains at most 10,000 per-account limiter entries per process.
- At capacity, it evicts the least-recently-used idle entry and gives the new account a dedicated limiter pair.
- It uses one shared overflow limiter pair only when every retained entry has running or queued work and none is safe to evict.

The request is not silently dropped at capacity. In the usual capacity case, it replaces an idle entry and runs through its own dedicated limiter pair. If all retained entries are busy, a task move or field update uses the shared overflow pair. It runs immediately when a concurrency slot is available, or waits in the existing FIFO queue. If it cannot get a slot within 30 seconds, it returns an explicit error and does not send the Todoist API request.

## Before and after

| Scenario | Before | After |
| --- | --- | --- |
| A request arrives for an account whose dedicated limiter pair already exists | Reuse that account's limiter pair | Unchanged: reuse it and mark it as most recently used |
| A dedicated limiter pair has no running or queued work for five minutes | Retain it until the process exits | Remove it when a later request triggers cleanup |
| A limiter pair has running or queued work | Retain it | Unchanged: never evict it while work remains |
| A request arrives for a new account while the registry is below capacity | Create and retain a dedicated limiter pair | Unchanged: create and retain a dedicated pair |
| A request arrives for a new account at capacity and at least one retained pair is idle | Create and retain entry 10,001, then continue growing | Evict the least-recently-used idle pair and create a dedicated pair for the new account |
| A request arrives for a new account at capacity and all retained pairs are busy | Create and retain entry 10,001, then continue growing | Use the shared overflow pair and keep the registry at 10,000 entries |
| A task move uses the shared overflow pair | No overflow path; every account added permanent state | Run immediately if the shared move lane is free, otherwise wait; one move runs at a time |
| A task field update uses the shared overflow pair | No overflow path; every account added permanent state | Run immediately if a shared write slot is free, otherwise wait; up to four writes run at a time |
| Queued work cannot start within 30 seconds | Return the existing queue-timeout error without sending the API request | Unchanged; this also protects the shared overflow path |

The shared overflow limiter applies collectively only when all retained account entries in that MCP server process are busy. This can add latency during an extreme burst, but it keeps both retained memory and concurrent API calls bounded. An account stays on the overflow pair until all of its current overflow work finishes, so concurrent calls for that account cannot split across different limiter pairs.

## Request flow

```mermaid
flowchart TD
    A[Receive authenticated MCP request and<br/>create request-scoped Todoist client] --> B[Compute an account key<br/>from the API token]
    B --> C{Does this account already have<br/>a dedicated limiter pair?}
    C -- Yes --> D[Reuse the dedicated pair<br/>and mark it as most recently used]
    C -- No --> E[Remove entries idle for 5 minutes<br/>with no running or queued work]
    E --> F{Registry below<br/>10,000 entries?}
    F -- Yes --> G[Create a dedicated limiter pair<br/>for this account]
    F -- No --> H{Is any retained<br/>limiter pair idle?}
    H -- Yes --> I[Evict the least-recently-used idle pair<br/>and create a dedicated pair]
    H -- No --> J[All retained pairs are busy<br/>Use the shared overflow pair]
    D --> K{Which internal Todoist API<br/>operation is about to run?}
    G --> K
    I --> K
    J --> K
    K -- Other operation --> L[Continue without these<br/>concurrency limiters]
    K -- Task move --> M[Enter move lane<br/>1 operation at a time]
    K -- Task field update --> N[Enter write lane<br/>Up to 4 operations at a time]
    M --> O{Concurrency slot available?}
    N --> O
    O -- Yes --> P[Send request to Todoist API]
    O -- No --> Q[Wait in FIFO queue<br/>for up to 30 seconds]
    Q -- Slot opens --> P
    Q -- 30 seconds elapse --> R[Return an explicit queue-timeout error<br/>Todoist API request was not sent]
    P --> S[Return the Todoist API result or error<br/>to the MCP tool]
```

The concurrency lanes currently apply to task moves and task field updates. Read-only tool calls are not delayed by these limiters.

## Safety properties

- The per-account limiter registry cannot contain more than 10,000 entries.
- The registry stores a SHA-256 digest, not the raw API token.
- A limiter pair with running or queued work is never evicted.
- At capacity, the least-recently-used idle pair is evicted before overflow is used.
- When every retained pair is busy, all affected request-scoped clients share one overflow pair, so creating a client per request cannot bypass the concurrency limits.
- An account stays assigned to overflow until all of its current overflow work finishes.
- Request-scoped client associations use a `WeakMap`, so they do not keep completed request clients alive.

## Verification

- Confirms that capacity pressure evicts an idle entry before using overflow.
- Confirms that a client which selected a limiter before eviction resolves the account's current pair when work starts.
- Confirms with two distinct account tokens that overflow clients share the concurrency limits when every retained entry is busy.
- Confirms that overflow clients remain separate from the fallback path for unregistered SDK clients.
- Confirms behaviorally that an expired entry with active work is not evicted under capacity pressure.
- Full test suite: 1,266 tests passed.

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
