### PR TITLE
fix: use paired SDK transport for compressed responses on Node 26

### DIFF
--- a/src/usage-tracking.test.ts
+++ b/src/usage-tracking.test.ts
@@ -9,9 +9,9 @@ import {
     runWithUsageTrackingContext,
 } from './usage-tracking.js'
 
-const getDefaultDispatcherMock = vi.fn<() => Promise<unknown | undefined>>(() =>
-    Promise.resolve(undefined),
-)
+const getDefaultTransportMock = vi.fn<
+    () => Promise<{ dispatcher: unknown; fetch?: typeof fetch } | undefined>
+>(() => Promise.resolve(undefined))
 
 function createJsonResponse(body: unknown = { ok: true }): Response {
     return new Response(JSON.stringify(body), {
@@ -193,39 +193,54 @@ describe('usage tracking', () => {
 
     describe('proxy dispatcher injection', () => {
         afterEach(async () => {
-            getDefaultDispatcherMock.mockReset()
-            getDefaultDispatcherMock.mockResolvedValue(undefined)
+            getDefaultTransportMock.mockReset()
+            getDefaultTransportMock.mockResolvedValue(undefined)
             await resetDefaultDispatcherForTests()
             resetDispatcherModuleLoaderForTests()
         })
 
-        it('attaches the env proxy dispatcher when createTrackedFetch uses native fetch', async () => {
-            const fakeDispatcher = { kind: 'env-http-proxy-agent', close: vi.fn() }
-            getDefaultDispatcherMock.mockResolvedValue(fakeDispatcher)
-            setDispatcherModuleLoaderForTests(async () => ({
-                getDefaultDispatcher: getDefaultDispatcherMock,
-            }))
+        it.each([false, true])(
+            'uses the paired fetch when global fetch is replaced after creation: %s',
+            async (replaceGlobalFetch) => {
+                const fakeDispatcher = { kind: 'env-http-proxy-agent', close: vi.fn() }
+                const pairedFetch = vi.fn(
+                    async (_url: RequestInfo | URL, options?: RequestInit) => {
+                        captured = options
+                        return createJsonResponse()
+                    },
+                )
+                getDefaultTransportMock.mockResolvedValue({
+                    dispatcher: fakeDispatcher,
+                    fetch: pairedFetch as unknown as typeof fetch,
+                })
+                setDispatcherModuleLoaderForTests(async () => ({
+                    getDefaultTransport: getDefaultTransportMock,
+                }))
 
-            let captured: RequestInit | undefined
-            const originalFetch = globalThis.fetch
-            globalThis.fetch = (async (_url: RequestInfo | URL, options?: RequestInit) => {
-                captured = options
-                return createJsonResponse()
-            }) as typeof fetch
+                let captured: RequestInit | undefined
+                const originalFetch = globalThis.fetch
+                const globalFetch = vi.fn<typeof fetch>()
+                globalThis.fetch = globalFetch
 
-            try {
-                const trackedFetch = createTrackedFetch()
-                await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
-            } finally {
-                globalThis.fetch = originalFetch
-            }
+                try {
+                    const trackedFetch = createTrackedFetch()
+                    if (replaceGlobalFetch) {
+                        globalThis.fetch = vi.fn<typeof fetch>()
+                    }
+                    await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
+                } finally {
+                    globalThis.fetch = originalFetch
+                }
 
-            expect(getDefaultDispatcherMock).toHaveBeenCalled()
-            expect(captured).toBeTruthy()
-            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
-                fakeDispatcher,
-            )
-        })
+                expect(getDefaultTransportMock).toHaveBeenCalled()
+                expect(pairedFetch).toHaveBeenCalled()
+                expect(globalFetch).not.toHaveBeenCalled()
+                expect(captured).toBeTruthy()
+                expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                    fakeDispatcher,
+                )
+            },
+        )
 
         it('does not attach a dispatcher when createTrackedFetch is given a stub', async () => {
             let captured: RequestInit | undefined
@@ -239,9 +254,36 @@ describe('usage tracking', () => {
 
             await trackedFetch('https://api.todoist.com/api/v1/tasks', { method: 'GET' })
 
-            expect(getDefaultDispatcherMock).not.toHaveBeenCalled()
+            expect(getDefaultTransportMock).not.toHaveBeenCalled()
             expect(captured).toBeTruthy()
             expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBeUndefined()
+        })
+
+        it('keeps a caller-supplied dispatcher on native fetch', async () => {
+            const callerDispatcher = { kind: 'caller-supplied' }
+            let captured: RequestInit | undefined
+            const originalFetch = globalThis.fetch
+            const globalFetch = vi.fn(async (_url: RequestInfo | URL, options?: RequestInit) => {
+                captured = options
+                return createJsonResponse()
+            })
+            globalThis.fetch = globalFetch as typeof fetch
+
+            try {
+                await createTrackedFetch()('https://api.todoist.com/api/v1/tasks', {
+                    method: 'GET',
+                    // dispatcher is a Node fetch extension not present in RequestInit types
+                    dispatcher: callerDispatcher,
+                } as RequestInit)
+            } finally {
+                globalThis.fetch = originalFetch
+            }
+
+            expect(getDefaultTransportMock).not.toHaveBeenCalled()
+            expect(globalFetch).toHaveBeenCalled()
+            expect((captured as unknown as { dispatcher?: unknown }).dispatcher).toBe(
+                callerDispatcher,
+            )
         })
     })
 
@@ -316,8 +358,10 @@ describe('usage tracking', () => {
 // createTodoistClient -> createTrackedFetch -> SDK path so a future SDK bump
 // that loosens the behaviour fails loudly in this repo.
 describe('createTodoistClient viewAttachment safety (Doist/Issues#20430)', () => {
-    afterEach(() => {
+    afterEach(async () => {
         vi.restoreAllMocks()
+        await resetDefaultDispatcherForTests()
+        resetDispatcherModuleLoaderForTests()
     })
 
     it('rejects non-attachment Todoist hosts without making a request', async () => {
@@ -350,6 +394,12 @@ describe('createTodoistClient viewAttachment safety (Doist/Issues#20430)', () =>
                 }),
             )
         vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock)
+        setDispatcherModuleLoaderForTests(async () => ({
+            getDefaultTransport: async () => ({
+                dispatcher: {},
+                fetch: fetchMock,
+            }),
+        }))
 
         const client = createTodoistClient('test-token')
         await client.viewAttachment('https://files.todoist.com/user_upload/file.png')

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -17,11 +17,16 @@ type UsageTrackingConfig = {
     sessionId?: string
 }
 
-type DispatcherModule = {
-    getDefaultDispatcher: () => Promise<unknown | undefined>
+type DefaultTransport = {
+    dispatcher: unknown
+    fetch?: typeof fetch
 }
 
-let defaultDispatcherPromise: Promise<unknown | undefined> | undefined
+type DispatcherModule = {
+    getDefaultTransport: () => Promise<DefaultTransport | undefined>
+}
+
+let defaultTransportPromise: Promise<DefaultTransport | undefined> | undefined
 const defaultDispatcherModuleLoader = async (): Promise<DispatcherModule> => {
     const todoistSdkEntry = require.resolve('@doist/todoist-sdk')
     const dispatcherModulePath = join(dirname(todoistSdkEntry), 'transport', 'http-dispatcher.js')
@@ -137,21 +142,21 @@ function mergeAbortSignals(
     }
 }
 
-async function getSdkDefaultDispatcher(): Promise<unknown | undefined> {
+async function getSdkDefaultTransport(): Promise<DefaultTransport | undefined> {
     if (!isNodeEnvironment()) {
         return undefined
     }
 
-    if (!defaultDispatcherPromise) {
-        defaultDispatcherPromise = dispatcherModuleLoader()
-            .then((dispatcherModule) => dispatcherModule.getDefaultDispatcher())
+    if (!defaultTransportPromise) {
+        defaultTransportPromise = dispatcherModuleLoader()
+            .then((dispatcherModule) => dispatcherModule.getDefaultTransport())
             .catch((error) => {
-                defaultDispatcherPromise = undefined
+                defaultTransportPromise = undefined
                 throw error
             })
     }
 
-    return defaultDispatcherPromise
+    return defaultTransportPromise
 }
 
 function isNodeEnvironment(): boolean {
@@ -159,15 +164,17 @@ function isNodeEnvironment(): boolean {
 }
 
 export async function resetDefaultDispatcherForTests(): Promise<void> {
-    if (!defaultDispatcherPromise) {
+    if (!defaultTransportPromise) {
         return
     }
 
-    const dispatcherPromise = defaultDispatcherPromise
-    defaultDispatcherPromise = undefined
-    await dispatcherPromise.then(
-        (dispatcher) =>
-            (dispatcher as { close?: () => void | Promise<void> } | undefined)?.close?.(),
+    const transportPromise = defaultTransportPromise
+    defaultTransportPromise = undefined
+    await transportPromise.then(
+        (transport) =>
+            (
+                transport?.dispatcher as { close?: () => void | Promise<void> } | undefined
+            )?.close?.(),
         () => undefined,
     )
 }
@@ -180,12 +187,27 @@ export function resetDispatcherModuleLoaderForTests(): void {
     dispatcherModuleLoader = defaultDispatcherModuleLoader
 }
 
-async function attachDispatcher(options: RequestInit): Promise<void> {
-    const dispatcher = await getSdkDefaultDispatcher()
-    if (dispatcher !== undefined) {
-        // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
-        options.dispatcher = dispatcher
+async function resolveRequestFetch(
+    baseFetch: typeof fetch,
+    options: RequestInit,
+): Promise<typeof fetch> {
+    if ('dispatcher' in options) {
+        return baseFetch
     }
+
+    const transport = await getSdkDefaultTransport()
+    if (!transport) {
+        return baseFetch
+    }
+
+    if (!('dispatcher' in options)) {
+        // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
+        options.dispatcher = transport.dispatcher
+    }
+
+    // The SDK's dispatcher decodes compressed response bodies itself. Its
+    // paired fetch must be used to avoid Node's global fetch decoding again.
+    return transport.fetch ?? baseFetch
 }
 
 function toCustomFetchResponse(response: Response): CustomFetchResponse {
@@ -224,11 +246,11 @@ export function createTrackedFetch(
                       ? { headers }
                       : {}),
             }
-            if (useDispatcher) {
-                await attachDispatcher(fetchOptions)
-            }
+            const requestFetch = useDispatcher
+                ? await resolveRequestFetch(baseFetch, fetchOptions)
+                : baseFetch
 
-            const response = await baseFetch(url, fetchOptions)
+            const response = await requestFetch(url, fetchOptions)
             return toCustomFetchResponse(response)
         } finally {
             cleanup()

--- a/src/usage-tracking.ts
+++ b/src/usage-tracking.ts
@@ -200,10 +200,8 @@ async function resolveRequestFetch(
         return baseFetch
     }
 
-    if (!('dispatcher' in options)) {
-        // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
-        options.dispatcher = transport.dispatcher
-    }
+    // @ts-expect-error - dispatcher is a valid option for Node's fetch but not in the TS types
+    options.dispatcher = transport.dispatcher
 
     // The SDK's dispatcher decodes compressed response bodies itself. Its
     // paired fetch must be used to avoid Node's global fetch decoding again.


### PR DESCRIPTION
## Overview

On Node 26, gzipped API responses fail with `terminated` because MCP pairs the SDK's decompressing dispatcher with Node's built-in fetch, which tries to decompress the body again. Use the fetch returned by `getDefaultTransport()` together with its dispatcher so compressed responses decode correctly.

# Pull Request

Closes #599

## Short description

Update the usage-tracking wrapper to use the SDK's paired transport. Explicit fetch implementations and caller-supplied dispatchers remain under caller control. Adjust the transport and attachment tests to exercise the paired fetch.

Validation: reproduced `terminated / incorrect header check` with the mismatched transport on Node 26.8.1; the patched tracked fetch reads the same local gzipped response successfully. On the published base (`35cdfce`), all 1,271 tests, type checking, and formatting passed, including 15 focused usage-tracking tests. Build and schema validation also passed during earlier preparation. Local review prompted a regression test and correction for global fetch replacement after client creation.

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.) — not applicable
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`. — not applicable

<!--
_Note:_ versioning is handled by [release-please](https://github.com/googleapis/release-please) action, based on the PR title.
-->
