### PR TITLE
fix: resolve inbox aliases in project overviews (Doist/Issues#21069)

### DIFF
--- a/src/tools/get-overview.test.ts
+++ b/src/tools/get-overview.test.ts
@@ -6,6 +6,7 @@ import {
     createMockProject,
     createMockSection,
     createMockTask,
+    createMockUser,
     createMockWorkspaceProject,
     TEST_ERRORS,
     TEST_IDS,
@@ -19,6 +20,7 @@ const mockTodoistApi = {
     getProject: vi.fn(),
     getSections: vi.fn(),
     getTasks: vi.fn(),
+    getUser: vi.fn(),
 } as unknown as Mocked<TodoistApi>
 
 const { GET_OVERVIEW } = ToolNames
@@ -272,6 +274,28 @@ describe(`${GET_OVERVIEW} tool`, () => {
             )
             expect(structuredContent.sections).toHaveLength(2)
             expect(structuredContent.tasks).toHaveLength(3)
+        })
+
+        it('should resolve inbox to the inbox project ID', async () => {
+            mockTodoistApi.getUser.mockResolvedValue(createMockUser())
+            mockTodoistApi.getProject.mockResolvedValue(
+                createMockProject({ id: TEST_IDS.PROJECT_INBOX }),
+            )
+            mockTodoistApi.getSections.mockResolvedValue({ results: [], nextCursor: null })
+            mockTodoistApi.getTasks.mockResolvedValue({ results: [], nextCursor: null })
+
+            await getOverview.execute({ projectId: 'inbox' }, mockTodoistApi)
+
+            expect(mockTodoistApi.getUser).toHaveBeenCalledTimes(1)
+            expect(mockTodoistApi.getProject).toHaveBeenCalledWith(TEST_IDS.PROJECT_INBOX)
+            expect(mockTodoistApi.getSections).toHaveBeenCalledWith({
+                projectId: TEST_IDS.PROJECT_INBOX,
+            })
+            expect(mockTodoistApi.getTasks).toHaveBeenCalledWith({
+                projectId: TEST_IDS.PROJECT_INBOX,
+                limit: 50,
+                cursor: undefined,
+            })
         })
 
         it('should handle project with no tasks', async () => {

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -6,7 +6,7 @@ import {
 } from '@doist/todoist-sdk'
 import { z } from 'zod'
 import type { TodoistTool } from '../todoist-tool.js'
-import { mapTask, type Project } from '../tool-helpers.js'
+import { mapTask, type Project, resolveInboxProjectId } from '../tool-helpers.js'
 import { ApiLimits } from '../utils/constants.js'
 import { SectionSchema, type SectionSummary, toSectionSummary } from '../utils/output-schemas.js'
 import { ToolNames } from '../utils/tool-names.js'
@@ -17,7 +17,7 @@ const ArgsSchema = {
         .min(1)
         .optional()
         .describe(
-            'Optional project ID. If provided, shows detailed overview of that project. If omitted, shows overview of all projects.',
+            'Optional project ID. Use "inbox" for the Inbox. If provided, shows detailed overview of that project. If omitted, shows overview of all projects.',
         ),
 }
 
@@ -435,8 +435,9 @@ const getOverview = {
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
     async execute(args, client) {
-        const result = args.projectId
-            ? await generateProjectOverview(client, args.projectId)
+        const projectId = await resolveInboxProjectId({ projectId: args.projectId, client })
+        const result = projectId
+            ? await generateProjectOverview(client, projectId)
             : await generateAccountOverview(client)
 
         return {


### PR DESCRIPTION
# Pull Request

Closes https://github.com/Doist/Issues/issues/21069

## Short description

Resolves the `inbox` project alias to the current user's Inbox project ID before generating a project overview.

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.