### PR TITLE
docs: state that get-overview without projectId returns no tasks

### DIFF
--- a/src/tools/__snapshots__/get-overview.test.ts.snap
+++ b/src/tools/__snapshots__/get-overview.test.ts.snap
@@ -6,6 +6,8 @@ exports[`get-overview tool > account overview (no projectId) > should generate a
 - Inbox Project: Inbox (id=inbox-project-id)
 - Project: test-abc123def456-project (id=6cfCcrrCFg2xP94Q)
   - Section: test-section (id=section-123)
+
+_Note: This overview lists projects and sections only; tasks are not included. Call get-overview with a projectId (or "inbox") to see a project's tasks._
 "
 `;
 
@@ -13,6 +15,8 @@ exports[`get-overview tool > account overview (no projectId) > should handle emp
 "# Personal Projects
 
 _No projects found._
+
+_Note: This overview lists projects and sections only; tasks are not included. Call get-overview with a projectId (or "inbox") to see a project's tasks._
 "
 `;
 

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -17,7 +17,7 @@ const ArgsSchema = {
         .min(1)
         .optional()
         .describe(
-            'Optional project ID. Use "inbox" for the Inbox. If provided, shows detailed overview of that project. If omitted, shows overview of all projects.',
+            'Optional project ID. Use "inbox" for the Inbox. If provided, returns that project\'s tasks grouped by section. If omitted, returns the project and section structure for the whole account with no tasks.',
         ),
 }
 
@@ -329,6 +329,10 @@ async function generateAccountOverview(
         lines.push('_No projects found._')
     }
     lines.push('')
+    lines.push(
+        '_Note: This overview lists projects and sections only; tasks are not included. Call get-overview with a projectId (or "inbox") to see a project\'s tasks._',
+        '',
+    )
     // Add explanation about nesting if there are nested projects
     const hasNested = (tree as ProjectWithChildren[]).some((p) => p.children.length > 0)
     if (hasNested) {
@@ -430,7 +434,7 @@ async function generateProjectOverview(
 const getOverview = {
     name: ToolNames.GET_OVERVIEW,
     description:
-        'Get a Markdown overview. If no projectId is provided, shows all projects with hierarchy and sections (useful for navigation). If projectId is provided, shows detailed overview of that specific project including all tasks grouped by sections.',
+        'Get a Markdown overview. Called without a projectId, returns the account\'s project and section structure only — no tasks — for navigation. Pass a projectId (or "inbox" for the Inbox) to get that project\'s tasks grouped by section.',
     parameters: ArgsSchema,
     outputSchema: OutputSchema,
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },

--- a/src/tools/get-overview.ts
+++ b/src/tools/get-overview.ts
@@ -330,7 +330,7 @@ async function generateAccountOverview(
     }
     lines.push('')
     lines.push(
-        '_Note: This overview lists projects and sections only; tasks are not included. Call get-overview with a projectId (or "inbox") to see a project\'s tasks._',
+        `_Note: This overview lists projects and sections only; tasks are not included. Call ${ToolNames.GET_OVERVIEW} with a projectId (or "inbox") to see a project's tasks._`,
         '',
     )
     // Add explanation about nesting if there are nested projects


### PR DESCRIPTION
# Pull Request

Closes #603

## Short description

`get-overview` without a `projectId` returns project and section structure only, with no tasks. That's intended, but the tool description never said so, and an assistant that received an empty task list had nothing telling it this was expected — so it reported the account as empty. This bites hardest on accounts with no projects, where everything lives in the Inbox and the response is legitimately empty of both.

This PR:

- Rewrites the tool description and the `projectId` parameter description to say plainly what each form returns, and names `"inbox"` as a valid `projectId` at the top level (valid since #602).
- Appends a `_Note: ..._` line to the account-overview Markdown so the assistant sees the same guidance in the response itself, not only in the description. `structuredContent` is unchanged.

## Eval

Ran `npm run eval` before (main) and after (this branch), 10 scenarios × 5 repeats × 2 models:

| | claude-haiku-4-5 | claude-sonnet-5 |
|---|---|---|
| before | 49/50 | 50/50 |
| after | 50/50 | 50/50 |

The one before-miss was `completed-via-activity` on Haiku (`initiatorId` omitted on `find-activity`), unrelated to this change. `today-includes-overdue`, the only scenario that names `get-overview`, was 100% on both models in both runs.

## PR Checklist

- [x] Added tests for bugs / new features (snapshots updated to cover the new note)
- [x] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

