### PR TITLE
fix: surface deleted tasks in task outputs (Doist/Issues#20642)

### DIFF
--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -82,6 +82,9 @@ describe('shared utilities', () => {
             const result = mapTask(mockTask)
 
             expect(result.isDeleted).toBe(true)
+            // The other half of the contract: a live task omits the field rather
+            // than carrying `isDeleted: false` through every list response.
+            expect(mapTask(createMockTask()).isDeleted).toBeUndefined()
             // Regression guard for Doist/Issues#20642: a deleted task is not a
             // completed one, so `checked` alone cannot be read as "active".
             expect(result.checked).toBe(false)

--- a/src/tool-helpers.test.ts
+++ b/src/tool-helpers.test.ts
@@ -71,8 +71,20 @@ describe('shared utilities', () => {
                 completedAt: undefined,
                 deadlineDate: undefined,
                 responsibleUid: undefined,
+                isDeleted: undefined,
                 addedAt: '2025-08-13T22:09:56.123Z',
             })
+        })
+
+        it('should flag a deleted task', () => {
+            const mockTask = createMockTask({ id: '321', isDeleted: true })
+
+            const result = mapTask(mockTask)
+
+            expect(result.isDeleted).toBe(true)
+            // Regression guard for Doist/Issues#20642: a deleted task is not a
+            // completed one, so `checked` alone cannot be read as "active".
+            expect(result.checked).toBe(false)
         })
 
         it('should handle recurring tasks', () => {

--- a/src/tool-helpers.ts
+++ b/src/tool-helpers.ts
@@ -333,6 +333,9 @@ function mapTask(task: Task) {
         duration: task.duration ? formatDuration(task.duration.amount) : undefined,
         responsibleUid: task.responsibleUid ?? undefined,
         assignedByUid: task.assignedByUid ?? undefined,
+        // Only emitted when true: a deleted task is the exception, and every list
+        // response would otherwise carry `isDeleted: false` on every task.
+        isDeleted: task.isDeleted || undefined,
         checked: task.checked,
         completedAt: task.completedAt?.toISOString() ?? undefined,
         addedAt: task.addedAt?.toISOString() ?? undefined,

--- a/src/tools/fetch-object.test.ts
+++ b/src/tools/fetch-object.test.ts
@@ -90,6 +90,21 @@ describe(`${FETCH_OBJECT} tool`, () => {
             })
         })
 
+        it('should flag a deleted task', async () => {
+            mockTodoistApi.getTask.mockResolvedValue(
+                createMockTask({ id: 'task123', content: 'Deleted task', isDeleted: true }),
+            )
+
+            const result = await fetchObject.execute(
+                { type: 'task', id: 'task123' },
+                mockTodoistApi,
+            )
+
+            expect(result.structuredContent?.object).toEqual(
+                expect.objectContaining({ isDeleted: true }),
+            )
+        })
+
         it('should handle task not found', async () => {
             mockTodoistApi.getTask.mockRejectedValue(new Error('Task not found'))
 

--- a/src/tools/fetch.test.ts
+++ b/src/tools/fetch.test.ts
@@ -289,6 +289,18 @@ describe(`${FETCH} tool`, () => {
             ).rejects.toThrow('Task not found')
         })
 
+        // Regression guard for Doist/Issues#20642: the API answers 200 for a
+        // soft-deleted task, and fetch used to return it as ordinary content.
+        it('should throw error for a deleted task', async () => {
+            mockTodoistApi.getTask.mockResolvedValue(
+                createMockTask({ id: TEST_IDS.TASK_1, content: 'Deleted task', isDeleted: true }),
+            )
+
+            await expect(
+                fetch.execute({ id: `task:${TEST_IDS.TASK_1}` }, mockTodoistApi),
+            ).rejects.toThrow(`Task ${TEST_IDS.TASK_1} not found: it has been deleted.`)
+        })
+
         it('should throw error for project fetch failure', async () => {
             mockTodoistApi.getProject.mockRejectedValue(new Error('Project not found'))
 

--- a/src/tools/fetch.ts
+++ b/src/tools/fetch.ts
@@ -62,6 +62,14 @@ const fetch = {
         if (type === 'task') {
             // Fetch task
             const task = await client.getTask(objectId)
+
+            // The API still answers 200 for a soft-deleted task. Returning it as a
+            // document would present a tombstone as live content, so treat it as
+            // absent — the same as any other object this tool cannot produce.
+            if (task.isDeleted) {
+                throw new Error(`Task ${objectId} not found: it has been deleted.`)
+            }
+
             const mappedTask = mapTask(task)
 
             // Build text content

--- a/src/utils/output-schemas.ts
+++ b/src/utils/output-schemas.ts
@@ -24,6 +24,7 @@ const TaskSchema = z.object({
     responsibleUid: z.string().optional(),
     isUncompletable: z.boolean().optional().describe('An organizational header, not a real task.'),
     assignedByUid: z.string().optional(),
+    isDeleted: z.boolean().optional().describe('True when deleted; absent otherwise.'),
     checked: z.boolean().describe('Whether the task is completed.'),
     completedAt: z.string().optional().describe('ISO 8601.'),
     addedAt: z.string().optional().describe('ISO 8601.'),

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -189,6 +189,7 @@ export function createMappedTask(overrides: Partial<MappedTask> = {}): MappedTas
         duration: undefined,
         responsibleUid: undefined,
         assignedByUid: undefined,
+        isDeleted: undefined,
         checked: false,
         completedAt: undefined,
         addedAt: undefined,


### PR DESCRIPTION
# Pull Request

Refs Doist/Issues#20642

## Short description

`mapTask` never included `isDeleted`, so no consumer of it could tell a soft-deleted
task from a live one. In Doist/Issues#20642 that meant `fetch` reported a task deleted
weeks earlier as an ordinary document whose only state field was `checked: false` —
read by support and engineering as "active" — while every backend list path correctly
excluded it. Seven weeks of investigation went into a task that was never there.

### What changed

- **`mapTask` emits `isDeleted`** (`src/tool-helpers.ts`, `TaskSchema` in
  `src/utils/output-schemas.ts`), so `fetch`, `fetch-object`, `find-tasks` and the rest
  can all see it. It is emitted **only when true**: a deleted task is the exception, and
  the alternative is `isDeleted: false` on every task of every list response. Output for
  live tasks is therefore byte-identical to before — no snapshot changed.
- **`fetch` throws for a deleted task** rather than returning a document. The backend
  wrongly answers HTTP 200 for one today (being fixed separately in Doist/Todoist), but a
  "fetch the full contents" tool presenting a tombstone as live content is what caused the
  incident, so it should not depend on that fix. The error path is the repo's existing one:
  `execute` throws, `registerTool` turns it into `getErrorOutput` / `isError: true`, the
  same shape `fetch` already uses for a malformed ID and `fetch-object` for a missing
  section.

### On `checked`

Checked as asked — **not the same defect, so left alone.** `checked` and `completedAt` are
both already in `mapTask` and both declared in `TaskSchema`; `fetch` puts both in its
metadata. Completion state was always visible. What made `checked: false` misleading in
#20642 was the absence of any deletion signal beside it, which is what this PR adds.

### Notes for review

- `fetch-object` still returns a deleted task rather than erroring, now with
  `isDeleted: true` on it. It is the general-purpose object reader and its structured
  output can carry the flag; `fetch` returns free-text `text` for a model to read and
  cannot. Happy to make both error if you would rather they match.
- **Deleted _projects_ are untouched** — `mapProject` omits `isDeleted` too, and `fetch`
  would still return a deleted project as a document. Same class of bug, out of scope for
  this incident; say the word and I will do it here or in a follow-up.
- **Token footprint:** tools/list payload 33205 → 33341 (+136), combined fixed cost
  34233 against the 35000 budget. `TaskSchema` is inlined once per tool that uses it, so
  the field's description is deliberately terse.
- `src/mcp-server.ts` `instructions` is unchanged — this adds an output field, not
  cross-tool routing guidance — so no `npm run eval` run was needed.
- `npm test` (1275 passed), `npm run type-check` and `npm run check` all green.

## PR Checklist

- [x] Added tests for bugs / new features
- [ ] Updated docs (README, etc.)
- [ ] New tools added to `getMcpServer` AND exported in `src/index.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQi5BfMsFf7f4issZD6bay
